### PR TITLE
1.7.2: allow minions to roam when holding shift+T; fix bug in ZDO comparison

### DIFF
--- a/ChebsNecromancy/Assets/Translations/English/localizations.json
+++ b/ChebsNecromancy/Assets/Translations/English/localizations.json
@@ -28,6 +28,8 @@
   "chebgonaz_batbeacon_desc": "Enemies that approach this baleful flame will find themselves beset upon by winged flappers.",
   
   "chebgonaz_notyourminion": "You don't own this minion and it ignores you.",
+  "chebgonaz_wait": "Wait",
+  "chebgonaz_follow": "Follow",
 
   "friendlyskeletonwand_attack": "Attack",
   "friendlyskeletonwand_follow": "Follow",

--- a/ChebsNecromancy/Assets/Translations/English/localizations.json
+++ b/ChebsNecromancy/Assets/Translations/English/localizations.json
@@ -30,6 +30,7 @@
   "chebgonaz_notyourminion": "You don't own this minion and it ignores you.",
   "chebgonaz_wait": "Wait",
   "chebgonaz_follow": "Follow",
+  "chebgonaz_roaming": "Roaming, master...",
 
   "friendlyskeletonwand_attack": "Attack",
   "friendlyskeletonwand_follow": "Follow",

--- a/ChebsNecromancy/BasePlugin.cs
+++ b/ChebsNecromancy/BasePlugin.cs
@@ -31,7 +31,7 @@ namespace ChebsNecromancy
     {
         public const string PluginGuid = "com.chebgonaz.ChebsNecromancy";
         public const string PluginName = "ChebsNecromancy";
-        public const string PluginVersion = "1.7.3";
+        public const string PluginVersion = "1.7.4";
         private const string ConfigFileName =  PluginGuid + ".cfg";
         private static readonly string ConfigFileFullPath = Path.Combine(Paths.ConfigPath, ConfigFileName);
 

--- a/ChebsNecromancy/BasePlugin.cs
+++ b/ChebsNecromancy/BasePlugin.cs
@@ -21,6 +21,7 @@ using Jotunn.Managers;
 using Jotunn.Utils;
 using UnityEngine;
 using Paths = BepInEx.Paths;
+
 // ReSharper disable InconsistentNaming
 // ReSharper disable UnusedParameter.Local
 
@@ -33,7 +34,7 @@ namespace ChebsNecromancy
     {
         public const string PluginGuid = "com.chebgonaz.ChebsNecromancy";
         public const string PluginName = "ChebsNecromancy";
-        public const string PluginVersion = "1.7.5";
+        public const string PluginVersion = "1.7.6";
         private const string ConfigFileName =  PluginGuid + ".cfg";
         private static readonly string ConfigFileFullPath = Path.Combine(Paths.ConfigPath, ConfigFileName);
 

--- a/ChebsNecromancy/BasePlugin.cs
+++ b/ChebsNecromancy/BasePlugin.cs
@@ -26,7 +26,7 @@ namespace ChebsNecromancy
     {
         public const string PluginGUID = "com.chebgonaz.ChebsNecromancy";
         public const string PluginName = "ChebsNecromancy";
-        public const string PluginVersion = "1.6.4";
+        public const string PluginVersion = "1.6.5";
         private const string ConfigFileName =  PluginGUID + ".cfg";
         private static readonly string ConfigFileFullPath = Path.Combine(BepInEx.Paths.ConfigPath, ConfigFileName);
 

--- a/ChebsNecromancy/BasePlugin.cs
+++ b/ChebsNecromancy/BasePlugin.cs
@@ -34,7 +34,7 @@ namespace ChebsNecromancy
     {
         public const string PluginGuid = "com.chebgonaz.ChebsNecromancy";
         public const string PluginName = "ChebsNecromancy";
-        public const string PluginVersion = "1.7.7";
+        public const string PluginVersion = "1.7.8";
         private const string ConfigFileName =  PluginGuid + ".cfg";
         private static readonly string ConfigFileFullPath = Path.Combine(Paths.ConfigPath, ConfigFileName);
 
@@ -314,28 +314,28 @@ namespace ChebsNecromancy
 
                 #region Structures   
                 GameObject spiritPylonPrefab = chebgonazAssetBundle.LoadAsset<GameObject>(SpiritPylon.ChebsRecipeConfig.PrefabName);
-                SpiritPylon spiritPylon = spiritPylonPrefab.AddComponent<SpiritPylon>();
+                spiritPylonPrefab.AddComponent<SpiritPylon>();
                 PieceManager.Instance.AddPiece(
                     SpiritPylon.ChebsRecipeConfig.GetCustomPieceFromPrefab(spiritPylonPrefab,
                     chebgonazAssetBundle.LoadAsset<Sprite>(SpiritPylon.ChebsRecipeConfig.IconName))
                     );
 
                 GameObject refuelerPylonPrefab = chebgonazAssetBundle.LoadAsset<GameObject>(RefuelerPylon.ChebsRecipeConfig.PrefabName);
-                RefuelerPylon refuelerPylon = refuelerPylonPrefab.AddComponent<RefuelerPylon>();
+                refuelerPylonPrefab.AddComponent<RefuelerPylon>();
                 PieceManager.Instance.AddPiece(
                     RefuelerPylon.ChebsRecipeConfig.GetCustomPieceFromPrefab(refuelerPylonPrefab,
                     chebgonazAssetBundle.LoadAsset<Sprite>(RefuelerPylon.ChebsRecipeConfig.IconName))
                     );
 
                 GameObject neckroGathererPylonPrefab = chebgonazAssetBundle.LoadAsset<GameObject>(NeckroGathererPylon.ChebsRecipeConfig.PrefabName);
-                NeckroGathererPylon neckroGathererPylon = neckroGathererPylonPrefab.AddComponent<NeckroGathererPylon>();
+                neckroGathererPylonPrefab.AddComponent<NeckroGathererPylon>();
                 PieceManager.Instance.AddPiece(
-                    RefuelerPylon.ChebsRecipeConfig.GetCustomPieceFromPrefab(neckroGathererPylonPrefab,
+                    NeckroGathererPylon.ChebsRecipeConfig.GetCustomPieceFromPrefab(neckroGathererPylonPrefab,
                     chebgonazAssetBundle.LoadAsset<Sprite>(NeckroGathererPylon.ChebsRecipeConfig.IconName))
                     );
 
                 GameObject batBeaconPrefab = chebgonazAssetBundle.LoadAsset<GameObject>(BatBeacon.ChebsRecipeConfig.PrefabName);
-                BatBeacon batBeacon = batBeaconPrefab.AddComponent<BatBeacon>();
+                batBeaconPrefab.AddComponent<BatBeacon>();
                 PieceManager.Instance.AddPiece(
                     BatBeacon.ChebsRecipeConfig.GetCustomPieceFromPrefab(batBeaconPrefab,
                     chebgonazAssetBundle.LoadAsset<Sprite>(BatBeacon.ChebsRecipeConfig.IconName))

--- a/ChebsNecromancy/BasePlugin.cs
+++ b/ChebsNecromancy/BasePlugin.cs
@@ -26,7 +26,7 @@ namespace ChebsNecromancy
     {
         public const string PluginGUID = "com.chebgonaz.ChebsNecromancy";
         public const string PluginName = "ChebsNecromancy";
-        public const string PluginVersion = "1.6.5";
+        public const string PluginVersion = "1.7.0";
         private const string ConfigFileName =  PluginGUID + ".cfg";
         private static readonly string ConfigFileFullPath = Path.Combine(BepInEx.Paths.ConfigPath, ConfigFileName);
 

--- a/ChebsNecromancy/BasePlugin.cs
+++ b/ChebsNecromancy/BasePlugin.cs
@@ -11,6 +11,7 @@ using ChebsNecromancy.Commands;
 using ChebsNecromancy.CustomPrefabs;
 using ChebsNecromancy.Items;
 using ChebsNecromancy.Minions;
+using ChebsNecromancy.Structures;
 using HarmonyLib;
 using Jotunn;
 using Jotunn.Configs;

--- a/ChebsNecromancy/BasePlugin.cs
+++ b/ChebsNecromancy/BasePlugin.cs
@@ -34,7 +34,7 @@ namespace ChebsNecromancy
     {
         public const string PluginGuid = "com.chebgonaz.ChebsNecromancy";
         public const string PluginName = "ChebsNecromancy";
-        public const string PluginVersion = "1.7.6";
+        public const string PluginVersion = "1.7.7";
         private const string ConfigFileName =  PluginGuid + ".cfg";
         private static readonly string ConfigFileFullPath = Path.Combine(Paths.ConfigPath, ConfigFileName);
 

--- a/ChebsNecromancy/BasePlugin.cs
+++ b/ChebsNecromancy/BasePlugin.cs
@@ -31,7 +31,7 @@ namespace ChebsNecromancy
     {
         public const string PluginGuid = "com.chebgonaz.ChebsNecromancy";
         public const string PluginName = "ChebsNecromancy";
-        public const string PluginVersion = "1.7.4";
+        public const string PluginVersion = "1.7.5";
         private const string ConfigFileName =  PluginGuid + ".cfg";
         private static readonly string ConfigFileFullPath = Path.Combine(Paths.ConfigPath, ConfigFileName);
 
@@ -771,23 +771,22 @@ namespace ChebsNecromancy
         [HarmonyPrefix]
         static bool Prefix(Tameable __instance, ref string __result)
         {
-            if (!__instance.m_nview.IsValid()
-                || !__instance.m_commandable
-                || !__instance.TryGetComponent(out MonsterAI monsterAI)
-                || Player.m_localPlayer == null)
-            {
-                __result = "";
-            }
-            else
+            if (__instance.m_nview.IsValid()
+                && __instance.m_commandable
+                && __instance.TryGetComponent(out UndeadMinion _)
+                && __instance.TryGetComponent(out MonsterAI monsterAI)
+                && Player.m_localPlayer != null)
             {
                 __result = monsterAI.GetFollowTarget() == Player.m_localPlayer.gameObject
-                ? Localization.instance.Localize("$chebgonaz_wait")
-                : Localization.instance.Localize("$chebgonaz_follow");
+                    ? Localization.instance.Localize("$chebgonaz_wait")
+                    : Localization.instance.Localize("$chebgonaz_follow");
+                return false; // deny base method completion
             }
 
-            return false; // deny base method completion
+            return true; // allow base method completion
         }
     }
+
     #endregion
 }
 

--- a/ChebsNecromancy/BasePlugin.cs
+++ b/ChebsNecromancy/BasePlugin.cs
@@ -31,7 +31,7 @@ namespace ChebsNecromancy
     {
         public const string PluginGuid = "com.chebgonaz.ChebsNecromancy";
         public const string PluginName = "ChebsNecromancy";
-        public const string PluginVersion = "1.7.1";
+        public const string PluginVersion = "1.7.2";
         private const string ConfigFileName =  PluginGuid + ".cfg";
         private static readonly string ConfigFileFullPath = Path.Combine(Paths.ConfigPath, ConfigFileName);
 

--- a/ChebsNecromancy/BasePlugin.cs
+++ b/ChebsNecromancy/BasePlugin.cs
@@ -31,7 +31,7 @@ namespace ChebsNecromancy
     {
         public const string PluginGuid = "com.chebgonaz.ChebsNecromancy";
         public const string PluginName = "ChebsNecromancy";
-        public const string PluginVersion = "1.7.2";
+        public const string PluginVersion = "1.7.3";
         private const string ConfigFileName =  PluginGuid + ".cfg";
         private static readonly string ConfigFileFullPath = Path.Combine(Paths.ConfigPath, ConfigFileName);
 

--- a/ChebsNecromancy/ChebsNecromancy.csproj
+++ b/ChebsNecromancy/ChebsNecromancy.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>ChebsNecromancy</RootNamespace>
     <AssemblyName>ChebsNecromancy</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>latest</LangVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <NuGetPackageImportStamp>

--- a/ChebsNecromancy/ChebsNecromancy.csproj
+++ b/ChebsNecromancy/ChebsNecromancy.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\JotunnLib.2.10.3\build\JotunnLib.props" Condition="Exists('..\packages\JotunnLib.2.10.3\build\JotunnLib.props')" />
+  <Import Project="..\packages\JotunnLib.2.10.4\build\JotunnLib.props" Condition="Exists('..\packages\JotunnLib.2.10.4\build\JotunnLib.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,6 +10,7 @@
     <RootNamespace>ChebsNecromancy</RootNamespace>
     <AssemblyName>ChebsNecromancy</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <LangVersion>8.0</LangVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <NuGetPackageImportStamp>
@@ -80,7 +81,7 @@
       <HintPath>..\packages\HarmonyX.2.10.1\lib\net45\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Jotunn">
-      <HintPath>..\packages\JotunnLib.2.10.3\lib\net462\Jotunn.dll</HintPath>
+      <HintPath>..\packages\JotunnLib.2.10.4\lib\net462\Jotunn.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>

--- a/ChebsNecromancy/ChebsNecromancy.csproj
+++ b/ChebsNecromancy/ChebsNecromancy.csproj
@@ -146,7 +146,6 @@
     <Compile Include="Items\SkeletonWand.cs" />
     <Compile Include="Items\SpectralShroud.cs" />
     <Compile Include="Minions\GuardianWraithMinion.cs" />
-    <Compile Include="Minions\SpiritPylon.cs" />
     <Compile Include="Minions\UndeadMinion.cs" />
     <Compile Include="Minions\SkeletonMinion.cs" />
     <Compile Include="Minions\DraugrMinion.cs" />
@@ -169,9 +168,6 @@
     <Compile Include="Items\BlackIronHelmet.cs" />
     <Compile Include="Minions\NeckroGathererMinion.cs" />
     <Compile Include="CustomPrefabs\LargeCargoCrate.cs" />
-    <Compile Include="Minions\RefuelerPylon.cs" />
-    <Compile Include="Minions\NeckroGathererPylon.cs" />
-    <Compile Include="Minions\BatBeacon.cs" />
     <Compile Include="Minions\BatBeaconBatMinion.cs" />
     <Compile Include="Items\SkeletonMace.cs" />
     <Compile Include="Items\SkeletonMace2.cs" />
@@ -183,6 +179,10 @@
     <Compile Include="Commands\KillNearbyNeckros.cs" />
     <Compile Include="Commands\SetMinionOwnership.cs" />
     <Compile Include="Minions\FreshMinion.cs" />
+    <Compile Include="Structures\BatBeacon.cs" />
+    <Compile Include="Structures\NeckroGathererPylon.cs" />
+    <Compile Include="Structures\RefuelerPylon.cs" />
+    <Compile Include="Structures\SpiritPylon.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/ChebsNecromancy/ChebsNecromancy.csproj
+++ b/ChebsNecromancy/ChebsNecromancy.csproj
@@ -181,6 +181,7 @@
     <Compile Include="Items\SkeletonHelmetLeatherPoison.cs" />
     <Compile Include="Commands\KillNearbyNeckros.cs" />
     <Compile Include="Commands\SetMinionOwnership.cs" />
+    <Compile Include="Minions\FreshMinion.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/ChebsNecromancy/Commands/KillAllMinions.cs
+++ b/ChebsNecromancy/Commands/KillAllMinions.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using ChebsNecromancy.Minions;
 using Jotunn.Entities;
+using Jotunn.Managers;
 
 namespace ChebsNecromancy.Commands
 {
@@ -18,9 +19,14 @@ namespace ChebsNecromancy.Commands
         public override void Run(string[] args)
         {
             List<Character> allCharacters = Character.GetAllCharacters();
-            List<Tuple<int, Character>> minionsFound = new List<Tuple<int, Character>>();
 
+            bool admin = SynchronizationManager.Instance.PlayerIsAdmin;
             bool force = args.Length > 0 && args[0].Equals("f");
+            if (force && !admin)
+            {
+                Console.instance.Print("Only admins can use the force argument with this command.");
+                return;
+            }
             
             foreach (Character item in allCharacters)
             {

--- a/ChebsNecromancy/Commands/KillNearbyNeckros.cs
+++ b/ChebsNecromancy/Commands/KillNearbyNeckros.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using ChebsNecromancy.Minions;
 using Jotunn.Entities;
+using Jotunn.Managers;
 
 namespace ChebsNecromancy.Commands
 {
@@ -18,9 +19,14 @@ namespace ChebsNecromancy.Commands
         public override void Run(string[] args)
         {
             List<Character> allCharacters = Character.GetAllCharacters();
-            List<Tuple<int, Character>> minionsFound = new List<Tuple<int, Character>>();
-
+            
+            bool admin = SynchronizationManager.Instance.PlayerIsAdmin;
             bool force = args.Length > 0 && args[0].Equals("f");
+            if (force && !admin)
+            {
+                Console.instance.Print("Only admins can use the force argument with this command.");
+                return;
+            }
             
             foreach (Character item in allCharacters)
             {

--- a/ChebsNecromancy/Commands/SetMinionOwnership.cs
+++ b/ChebsNecromancy/Commands/SetMinionOwnership.cs
@@ -50,8 +50,9 @@ namespace ChebsNecromancy.Commands
             {
                 if (character.TryGetComponent(out UndeadMinion undeadMinion))
                 {
-                    Console.instance.Print($"Setting '{character.name}'s owner to '{args[0]}'");
+                    Console.instance.Print($"Setting '{character.name}'s owner to '{args[0]}' and scaling to {playerNecromancyLevel}.");
                     undeadMinion.SetUndeadMinionMaster(args[0]);
+                    undeadMinion.SetCreatedAtLevel(playerNecromancyLevel);
 
                     // also scale minion health to player's setup
                     if (undeadMinion is SkeletonMinion)

--- a/ChebsNecromancy/Commands/SetMinionOwnership.cs
+++ b/ChebsNecromancy/Commands/SetMinionOwnership.cs
@@ -2,7 +2,6 @@
 // console command to kill all player's minions.
 // attention: only kills THEIR minions
 
-using System;
 using System.Collections.Generic;
 using ChebsNecromancy.Minions;
 using Jotunn.Entities;

--- a/ChebsNecromancy/Common/ChebsRecipe.cs
+++ b/ChebsNecromancy/Common/ChebsRecipe.cs
@@ -1,7 +1,7 @@
-﻿using BepInEx.Configuration;
+﻿using System.Linq;
+using BepInEx.Configuration;
 using Jotunn.Configs;
 using Jotunn.Entities;
-using System.Linq;
 using UnityEngine;
 using Logger = Jotunn.Logger;
 

--- a/ChebsNecromancy/Items/DraugrWand.cs
+++ b/ChebsNecromancy/Items/DraugrWand.cs
@@ -261,7 +261,14 @@ namespace ChebsNecromancy.Items
                 }
                 else if (WaitButton != null && ZInput.GetButton(WaitButton.Name))
                 {
-                    MakeNearbyMinionsFollow(Player.m_localPlayer, DraugrSetFollowRange.Value, false);
+                    if (ExtraResourceConsumptionUnlocked)
+                    {
+                        MakeNearbyMinionsRoam(Player.m_localPlayer, DraugrSetFollowRange.Value);
+                    }
+                    else
+                    {
+                        MakeNearbyMinionsFollow(Player.m_localPlayer, DraugrSetFollowRange.Value, false);   
+                    }
                     return true;
                 }
                 else if (TeleportButton != null && ZInput.GetButton(TeleportButton.Name))

--- a/ChebsNecromancy/Items/SkeletonWand.cs
+++ b/ChebsNecromancy/Items/SkeletonWand.cs
@@ -329,7 +329,14 @@ namespace ChebsNecromancy.Items
             }
             if (WaitButton != null && ZInput.GetButton(WaitButton.Name))
             {
-                MakeNearbyMinionsFollow(Player.m_localPlayer, SkeletonSetFollowRange.Value, false);
+                if (ExtraResourceConsumptionUnlocked)
+                {
+                    MakeNearbyMinionsRoam(Player.m_localPlayer, SkeletonSetFollowRange.Value);
+                }
+                else
+                {
+                    MakeNearbyMinionsFollow(Player.m_localPlayer, SkeletonSetFollowRange.Value, false);   
+                }
                 return true;
             }
             if (TeleportButton != null && ZInput.GetButton(TeleportButton.Name))

--- a/ChebsNecromancy/Items/Wand.cs
+++ b/ChebsNecromancy/Items/Wand.cs
@@ -5,7 +5,6 @@ using ChebsNecromancy.Minions;
 using Jotunn.Configs;
 using Jotunn.Managers;
 using UnityEngine;
-using Logger = Jotunn.Logger;
 
 namespace ChebsNecromancy.Items
 {

--- a/ChebsNecromancy/Items/Wand.cs
+++ b/ChebsNecromancy/Items/Wand.cs
@@ -5,6 +5,7 @@ using ChebsNecromancy.Minions;
 using Jotunn.Configs;
 using Jotunn.Managers;
 using UnityEngine;
+using Logger = Jotunn.Logger;
 
 namespace ChebsNecromancy.Items
 {
@@ -200,6 +201,25 @@ namespace ChebsNecromancy.Items
 
         public virtual bool HandleInputs() { return false; }
 
+        public void MakeNearbyMinionsRoam(Player player, float radius)
+        {
+            List<Character> allCharacters = new();
+            Character.GetCharactersInRange(player.transform.position, radius, allCharacters);
+            foreach (var character in allCharacters)
+            {
+                if (character.IsDead()) continue;
+                
+                UndeadMinion minion = character.GetComponent<UndeadMinion>();
+                if (minion == null || !minion.canBeCommanded
+                                   || !minion.BelongsToPlayer(player.GetPlayerName())) continue;
+                
+                if (character.GetComponent<MonsterAI>().GetFollowTarget() != player.gameObject) continue;
+
+                MessageHud.instance.ShowMessage(MessageHud.MessageType.Center, "$chebgonaz_roaming");
+                minion.Roam();
+            }
+        }
+        
         public void MakeNearbyMinionsFollow(Player player, float radius, bool follow)
         {
             // based off BaseAI.FindClosestCreature

--- a/ChebsNecromancy/Items/Wand.cs
+++ b/ChebsNecromancy/Items/Wand.cs
@@ -14,7 +14,7 @@ namespace ChebsNecromancy
 {
     internal class Wand : Item
     {
-        public ConfigEntry<bool> followByDefault;
+        public static ConfigEntry<bool> followByDefault;
 
         public ConfigEntry<KeyCode> CreateMinionConfig;
         public ConfigEntry<InputManager.GamepadButton> CreateMinionGamepadConfig;

--- a/ChebsNecromancy/Minions/BatBeaconBatMinion.cs
+++ b/ChebsNecromancy/Minions/BatBeaconBatMinion.cs
@@ -11,7 +11,7 @@ namespace ChebsNecromancy.Minions
         {
             base.Awake();
             canBeCommanded = false;
-            killAt = Time.time + Structures.BatBeacon.BatDuration.Value;
+            killAt = Time.time + BatBeacon.BatDuration.Value;
         }
 
         private void Update()

--- a/ChebsNecromancy/Minions/BatBeaconBatMinion.cs
+++ b/ChebsNecromancy/Minions/BatBeaconBatMinion.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using ChebsNecromancy.Structures;
+using UnityEngine;
 
 namespace ChebsNecromancy.Minions
 {

--- a/ChebsNecromancy/Minions/DraugrMinion.cs
+++ b/ChebsNecromancy/Minions/DraugrMinion.cs
@@ -84,6 +84,7 @@ namespace ChebsNecromancy.Minions
             // FreshMinion.cs file.
             FreshMinion freshMinion = GetComponent<FreshMinion>();
             MonsterAI monsterAI = GetComponent<MonsterAI>();
+            monsterAI.m_randomMoveRange = RoamRange.Value;
             if (!Wand.FollowByDefault.Value || freshMinion == null)
             {
                 WaitAtRecordedPosition();

--- a/ChebsNecromancy/Minions/DraugrMinion.cs
+++ b/ChebsNecromancy/Minions/DraugrMinion.cs
@@ -87,7 +87,7 @@ namespace ChebsNecromancy.Minions
             monsterAI.m_randomMoveRange = RoamRange.Value;
             if (!Wand.FollowByDefault.Value || freshMinion == null)
             {
-                WaitAtRecordedPosition();
+                RoamFollowOrWait();
             }
 
             if (freshMinion != null)

--- a/ChebsNecromancy/Minions/DraugrMinion.cs
+++ b/ChebsNecromancy/Minions/DraugrMinion.cs
@@ -41,12 +41,12 @@ namespace ChebsNecromancy.Minions
             _createdOrderIncrementer++;
             createdOrder = _createdOrderIncrementer;
 
-            StartCoroutine(WaitForLocalPlayer());
+            StartCoroutine(WaitForZNet());
         }
 
-        IEnumerator WaitForLocalPlayer()
+        IEnumerator WaitForZNet()
         {
-            yield return new WaitUntil(() => Player.m_localPlayer != null);
+            yield return new WaitUntil(() => ZNetScene.instance != null);
 
             ScaleStats(GetCreatedAtLevel());
 

--- a/ChebsNecromancy/Minions/FreshMinion.cs
+++ b/ChebsNecromancy/Minions/FreshMinion.cs
@@ -1,0 +1,18 @@
+﻿using UnityEngine;
+
+namespace ChebsNecromancy
+{
+    internal class FreshMinion : MonoBehaviour
+    {
+        // Attention: ONLY add FreshMinion to a freshly created by a wand.
+        // Under no other circumstances should it be added to a minion.
+        // This is to get around a very annoying problem in the
+        // merge request below where if default follow is enabled minions
+        // will not attack.
+        //
+        // FreshMinon must ALWAYS be added BEFORE the UndeadMinion component.
+        // but ONLY if creating freshly from a wand.
+        //
+        // https://github.com/jpw1991/chebs-necromancy/pull/68
+    }
+}

--- a/ChebsNecromancy/Minions/NeckroGathererMinion.cs
+++ b/ChebsNecromancy/Minions/NeckroGathererMinion.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using BepInEx;
 using BepInEx.Configuration;
 using ChebsNecromancy.CustomPrefabs;
-using HarmonyLib;
 using UnityEngine;
 
 namespace ChebsNecromancy.Minions

--- a/ChebsNecromancy/Minions/RefuelerPylon.cs
+++ b/ChebsNecromancy/Minions/RefuelerPylon.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using BepInEx;
@@ -146,25 +147,34 @@ namespace ChebsNecromancy.Minions
             {
                 yield return new WaitForSeconds(RefuelerUpdateInterval.Value);
 
-                GetNearbySmelters().ForEach(ManageSmelter);
+                Tuple<List<Smelter>, List<Fireplace>> tuple = GetNearbySmeltersAndFireplaces();
+
+                List<Smelter> smelters = tuple.Item1;
+                smelters.ForEach(ManageSmelter);
+                List<Fireplace> fireplaces = tuple.Item2;
+                fireplaces.ForEach(ManageFireplace);
+                
             }
         }
 
-        private List<Smelter> GetNearbySmelters()
+        private Tuple<List<Smelter>, List<Fireplace>> GetNearbySmeltersAndFireplaces()
         {
-            // find and return smelters in range
+            // find and return smelters and fireplaces in range
 
             Collider[] nearbyColliders = Physics.OverlapSphere(transform.position + Vector3.up, SightRadius.Value, PieceMask);
             if (nearbyColliders.Length < 1) return null;
 
-            List<Smelter> result = new List<Smelter>();
-            nearbyColliders.ToList().ForEach(collider =>
+            List<Smelter> smelters = new();
+            List<Fireplace> fireplaces = new();
+            nearbyColliders.ToList().ForEach(nearbyCollider =>
             {
-                Smelter smelter = collider.GetComponentInParent<Smelter>();
-                if (smelter != null) { result.Add(smelter); }
+                Smelter smelter = nearbyCollider.GetComponentInParent<Smelter>();
+                if (smelter != null) smelters.Add(smelter);
+                Fireplace fireplace = nearbyCollider.GetComponentInParent<Fireplace>();
+                if (fireplace != null) fireplaces.Add(fireplace);
             });
 
-            return result;
+            return new Tuple<List<Smelter>, List<Fireplace>>(smelters, fireplaces);
         }
 
         private void ManageSmelter(Smelter smelter)
@@ -232,6 +242,25 @@ namespace ChebsNecromancy.Minions
                 {
                     smelter.SetAnimation(true);
                 }
+            }
+        }
+
+        private void ManageFireplace(Fireplace fireplace)
+        {
+            float currentFuel = fireplace.m_nview.GetZDO().GetFloat("fuel");
+            // fuel is always an incomplete number like 5.98/6.00 because the moment you add the fuel
+            // it begins decreasing. So minus 1 from the max so we only add fuel if it is something like
+            // 4.98/6.00
+            if (currentFuel >= fireplace.m_maxFuel-1) return;
+            
+            Inventory inventory = Container.GetInventory();
+
+            if (inventory == null) return;
+
+            if (inventory.HaveItem(fireplace.m_fuelItem.m_itemData.m_shared.m_name))
+            {
+                fireplace.m_nview.InvokeRPC("AddFuel");
+                inventory.RemoveItem(fireplace.m_fuelItem.m_itemData.m_shared.m_name, 1);
             }
         }
     }

--- a/ChebsNecromancy/Minions/SkeletonMinion.cs
+++ b/ChebsNecromancy/Minions/SkeletonMinion.cs
@@ -49,36 +49,52 @@ namespace ChebsNecromancy.Minions
         {
             yield return new WaitUntil(() => Player.m_localPlayer != null);
 
-            ScaleStats(Player.m_localPlayer.GetSkillLevel(SkillManager.Instance.GetSkill(BasePlugin.necromancySkillIdentifier).m_skill));
+            ScaleStats(GetCreatedAtLevel());
 
             // by the time player arrives, ZNet stuff is certainly ready
-            if (TryGetComponent(out Humanoid humanoid))
+            if (!TryGetComponent(out Humanoid humanoid))
             {
-                // VisEquipment remembers what armor the skeleton is wearing.
-                // Exploit this to reapply the armor so the armor values work
-                // again.
-                List<int> equipmentHashes = new List<int>()
+                Jotunn.Logger.LogError("Humanoid component missing!");
+                yield break;
+            }
+
+            // VisEquipment remembers what armor the skeleton is wearing.
+            // Exploit this to reapply the armor so the armor values work
+            // again.
+            List<int> equipmentHashes = new List<int>()
                 {
                     humanoid.m_visEquipment.m_currentChestItemHash,
                     humanoid.m_visEquipment.m_currentLegItemHash,
                     humanoid.m_visEquipment.m_currentHelmetItemHash
                 };
-                equipmentHashes.ForEach(hash =>
-                {
-                    ZNetScene.instance.GetPrefab(hash);
+            equipmentHashes.ForEach(hash =>
+            {
+                ZNetScene.instance.GetPrefab(hash);
 
-                    GameObject equipmentPrefab = ZNetScene.instance.GetPrefab(hash);
-                    if (equipmentPrefab != null)
-                    {
-                        //Jotunn.Logger.LogInfo($"Giving default item {equipmentPrefab.name}");
-                        humanoid.GiveDefaultItem(equipmentPrefab);
-                    }
-                });
-            }
+                GameObject equipmentPrefab = ZNetScene.instance.GetPrefab(hash);
+                if (equipmentPrefab != null)
+                {
+                    //Jotunn.Logger.LogInfo($"Giving default item {equipmentPrefab.name}");
+                    humanoid.GiveDefaultItem(equipmentPrefab);
+                }
+            });
 
             RestoreDrops();
 
-            WaitAtRecordedPosition();
+            // wondering what the code below does? Check comments in the
+            // FreshMinion.cs file.
+            FreshMinion freshMinion = GetComponent<FreshMinion>();
+            MonsterAI monsterAI = GetComponent<MonsterAI>();
+            if (!Wand.followByDefault.Value || freshMinion == null)
+            {
+                WaitAtRecordedPosition();
+            }
+
+            if (freshMinion != null)
+            {
+                // remove the component
+                GameObject.Destroy(freshMinion);
+            }
         }
 
         public virtual void ScaleStats(float necromancyLevel)

--- a/ChebsNecromancy/Minions/SkeletonMinion.cs
+++ b/ChebsNecromancy/Minions/SkeletonMinion.cs
@@ -86,6 +86,7 @@ namespace ChebsNecromancy.Minions
             // FreshMinion.cs file.
             FreshMinion freshMinion = GetComponent<FreshMinion>();
             MonsterAI monsterAI = GetComponent<MonsterAI>();
+            monsterAI.m_randomMoveRange = RoamRange.Value;
             if (!Wand.FollowByDefault.Value || freshMinion == null)
             {
                 WaitAtRecordedPosition();

--- a/ChebsNecromancy/Minions/SkeletonMinion.cs
+++ b/ChebsNecromancy/Minions/SkeletonMinion.cs
@@ -43,16 +43,15 @@ namespace ChebsNecromancy.Minions
             _createdOrderIncrementer++;
             createdOrder = _createdOrderIncrementer;
 
-            StartCoroutine(WaitForLocalPlayer());
+            StartCoroutine(WaitForZNet());
         }
 
-        IEnumerator WaitForLocalPlayer()
+        IEnumerator WaitForZNet()
         {
-            yield return new WaitUntil(() => Player.m_localPlayer != null);
-
+            yield return new WaitUntil(() => ZNetScene.instance != null);
+            
             ScaleStats(GetCreatedAtLevel());
-
-            // by the time player arrives, ZNet stuff is certainly ready
+            
             if (!TryGetComponent(out Humanoid humanoid))
             {
                 Logger.LogError("Humanoid component missing!");
@@ -63,11 +62,11 @@ namespace ChebsNecromancy.Minions
             // Exploit this to reapply the armor so the armor values work
             // again.
             List<int> equipmentHashes = new List<int>()
-                {
-                    humanoid.m_visEquipment.m_currentChestItemHash,
-                    humanoid.m_visEquipment.m_currentLegItemHash,
-                    humanoid.m_visEquipment.m_currentHelmetItemHash
-                };
+            {
+                humanoid.m_visEquipment.m_currentChestItemHash,
+                humanoid.m_visEquipment.m_currentLegItemHash,
+                humanoid.m_visEquipment.m_currentHelmetItemHash
+            };
             equipmentHashes.ForEach(hash =>
             {
                 ZNetScene.instance.GetPrefab(hash);
@@ -75,7 +74,6 @@ namespace ChebsNecromancy.Minions
                 GameObject equipmentPrefab = ZNetScene.instance.GetPrefab(hash);
                 if (equipmentPrefab != null)
                 {
-                    //Jotunn.Logger.LogInfo($"Giving default item {equipmentPrefab.name}");
                     humanoid.GiveDefaultItem(equipmentPrefab);
                 }
             });
@@ -107,9 +105,6 @@ namespace ChebsNecromancy.Minions
                 Logger.LogError("ScaleStats: Character component is null!");
                 return;
             }
-
-            // only scale player's skeletons, not other ppls
-            if (!BelongsToPlayer(Player.m_localPlayer.GetPlayerName())) return;
 
             float health = SkeletonWand.SkeletonBaseHealth.Value + necromancyLevel * SkeletonWand.SkeletonHealthMultiplier.Value;
             character.SetMaxHealth(health);

--- a/ChebsNecromancy/Minions/SkeletonMinion.cs
+++ b/ChebsNecromancy/Minions/SkeletonMinion.cs
@@ -89,7 +89,7 @@ namespace ChebsNecromancy.Minions
             monsterAI.m_randomMoveRange = RoamRange.Value;
             if (!Wand.FollowByDefault.Value || freshMinion == null)
             {
-                WaitAtRecordedPosition();
+                RoamFollowOrWait();
             }
 
             if (freshMinion != null)

--- a/ChebsNecromancy/Minions/SpiritPylonGhostMinion.cs
+++ b/ChebsNecromancy/Minions/SpiritPylonGhostMinion.cs
@@ -11,7 +11,7 @@ namespace ChebsNecromancy.Minions
         {
             base.Awake();
             canBeCommanded = false;
-            killAt = Time.time + Structures.SpiritPylon.GhostDuration.Value;
+            killAt = Time.time + SpiritPylon.GhostDuration.Value;
         }
 
         private void Update()

--- a/ChebsNecromancy/Minions/SpiritPylonGhostMinion.cs
+++ b/ChebsNecromancy/Minions/SpiritPylonGhostMinion.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using ChebsNecromancy.Structures;
+using UnityEngine;
 
 namespace ChebsNecromancy.Minions
 {

--- a/ChebsNecromancy/Minions/UndeadMinion.cs
+++ b/ChebsNecromancy/Minions/UndeadMinion.cs
@@ -37,6 +37,7 @@ namespace ChebsNecromancy
 
         public static ConfigEntry<CleanupType> cleanupAfter;
         public static ConfigEntry<int> cleanupDelay;
+        public static ConfigEntry<bool> commandable;
 
         protected float cleanupAt;
 
@@ -59,6 +60,8 @@ namespace ChebsNecromancy
             cleanupDelay = plugin.Config.Bind("UndeadMinion (Server Synced)", "CleanupDelay",
                 300, new ConfigDescription("The delay, in seconds, after which a minion will be destroyed. It has no effect if CleanupAfter is set to None.", null,
                 new ConfigurationManagerAttributes { IsAdminOnly = true }));
+            commandable = plugin.Config.Bind("UndeadMinion (Client)", "Commandable",
+                true, new ConfigDescription("If true, minions can be commanded individually with E (or equivalent) keybind."));
         }
 
         public virtual void Awake()
@@ -68,6 +71,8 @@ namespace ChebsNecromancy
             {
                 // let the minions generate a little necromancy XP for their master
                 tameable.m_levelUpOwnerSkill = SkillManager.Instance.GetSkill(BasePlugin.necromancySkillIdentifier).m_skill;
+
+                tameable.m_commandable = commandable.Value;
             }
 
             if (cleanupAfter.Value == CleanupType.Time)

--- a/ChebsNecromancy/Minions/UndeadMinion.cs
+++ b/ChebsNecromancy/Minions/UndeadMinion.cs
@@ -44,6 +44,7 @@ namespace ChebsNecromancy
         public const string minionDropsZDOKey = "UndeadMinionDrops";
         public const string minionWaitPosZDOKey = "UndeadMinionWaitPosition";
         public const string minionWaitObjectName = "UndeadMinionWaitPositionObject";
+        public const string minionCreatedAtLevelKey = "UndeadMinionCreatedAtLevel";
 
         #region CleanupAfterLogout
         private const float nextPlayerOnlineCheckInterval = 15f;
@@ -148,14 +149,14 @@ namespace ChebsNecromancy
                 Jotunn.Logger.LogError($"Cannot SetUndeadMinionMaster to {playerName} because it has no ZNetView component.");
             }
         }
-        #endregion
+
         public bool BelongsToPlayer(string playerName)
         {
             return TryGetComponent(out ZNetView zNetView) 
                 && zNetView.GetZDO().GetString(minionOwnershipZDOKey, "")
                 .Equals(playerName);
         }
-
+        #endregion
         #region DropsZDO
         public void RecordDrops(CharacterDrop characterDrop)
         {
@@ -289,5 +290,26 @@ namespace ChebsNecromancy
             RecordWaitPosition(waitPosition);
             WaitAtRecordedPosition();
         }
+
+        #region CreatedAtLevelZDO
+        public void SetCreatedAtLevel(float necromancyLevel)
+        {
+            // We store the level the minion was created at so it can be scaled
+            // correctly in the Awake function
+            if (!TryGetComponent(out ZNetView zNetView))
+            {
+                Jotunn.Logger.LogError($"Cannot SetCreatedAtLevel to {necromancyLevel} because it has no ZNetView component.");
+                return;
+            }
+            zNetView.GetZDO().Set(minionCreatedAtLevelKey, necromancyLevel);
+        }
+
+        public float GetCreatedAtLevel()
+        {
+            return TryGetComponent(out ZNetView zNetView)
+                ? zNetView.GetZDO().GetFloat(minionCreatedAtLevelKey, 1f)
+                : 1f;
+        }
+        #endregion
     }
 }

--- a/ChebsNecromancy/Minions/UndeadMinion.cs
+++ b/ChebsNecromancy/Minions/UndeadMinion.cs
@@ -328,7 +328,11 @@ namespace ChebsNecromancy.Minions
         public void Roam()
         {
             RecordWaitPosition(StatusRoaming);
-            if (!TryGetComponent(out MonsterAI monsterAI)) return;
+            if (!TryGetComponent(out MonsterAI monsterAI))
+            {
+                Logger.LogError($"Cannot Roam because {name} has no MonsterAI component!");
+                return;
+            }
             // clear out current wait object if it exists
             GameObject currentFollowTarget = monsterAI.GetFollowTarget();
             if (currentFollowTarget != null && currentFollowTarget.name == MinionWaitObjectName)
@@ -352,11 +356,15 @@ namespace ChebsNecromancy.Minions
             zNetView.GetZDO().Set(MinionCreatedAtLevelKey, necromancyLevel);
         }
 
-        public float GetCreatedAtLevel()
+        protected float GetCreatedAtLevel()
         {
-            return TryGetComponent(out ZNetView zNetView)
-                ? zNetView.GetZDO().GetFloat(MinionCreatedAtLevelKey, 1f)
-                : 1f;
+            if (!TryGetComponent(out ZNetView zNetView))
+            {
+                Logger.LogError($"Cannot read {MinionCreatedAtLevelKey} because it has no ZNetView component.");
+                return 1f;
+            }
+
+            return zNetView.GetZDO().GetFloat(MinionCreatedAtLevelKey, 1f);
         }
         #endregion
     }

--- a/ChebsNecromancy/Package/README.md
+++ b/ChebsNecromancy/Package/README.md
@@ -112,6 +112,7 @@ You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
 Date | Version | Notes
 --- | --- | ---
+09/02/2023 | 1.7.5 | Neckro messages hideable; Neckro messages improved
 07/02/2023 | 1.7.4 | refueler pylons can now refuel fireplaces eg. torches, bonfires, etc.
 06/02/2023 | 1.7.3 | minions remember if they were following a player after player logs off, then continue following when player returns
 05/02/2023 | 1.7.2 | allow minions to roam when holding shift+T; fix bug in ZDO comparison

--- a/ChebsNecromancy/Package/README.md
+++ b/ChebsNecromancy/Package/README.md
@@ -112,6 +112,7 @@ You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
 Date | Version | Notes
 --- | --- | ---
+10/02/2023 | 1.7.6 | Dracbjorn's config overhaul; optimise imports
 09/02/2023 | 1.7.5 | Neckro messages hideable; Neckro messages improved
 07/02/2023 | 1.7.4 | refueler pylons can now refuel fireplaces eg. torches, bonfires, etc.
 06/02/2023 | 1.7.3 | minions remember if they were following a player after player logs off, then continue following when player returns

--- a/ChebsNecromancy/Package/README.md
+++ b/ChebsNecromancy/Package/README.md
@@ -108,7 +108,7 @@ You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
 Date | Version | Notes
 --- | --- | ---
-04/02/2023 | 1.7.1 | lint the entire project; catch and fix a few instances of MonoBehaviours accidently being instantiated with new -> a big no-no
+05/02/2023 | 1.7.1 | allow admins to ignore ownership with commands; fix bug where players wouldnt be found by command; lint the entire project; catch and fix a few instances of MonoBehaviours accidently being instantiated with new -> a big no-no
 03/02/2023 | 1.7.0 | minions now remember the necromancy level with which they're created and scale to that; refactor SkeletonWand and DraugrWand code to be more uniform to make diffing easier; fix a bug where minions set to follow automatically would have bugged AI with the 1.6.4 improvements; minion commandability exposed to config; commands issued via E also update ZDO; hover text for interact patched
 01/02/2023 | 1.6.4 | minions can be configured to drop their crafting requirements on death; hold position now works in that minions no longer wander around; wait positions are now recorded and stored so that minions return to where they were last waiting after chasing something off
 28/01/2023 | 1.6.3 | add optional timer to kill any minion after X seconds; overhaul minion ownership checks to accurately store and retrieve the minion's creator; minions will only obey commands from their creators and ignore others

--- a/ChebsNecromancy/Package/README.md
+++ b/ChebsNecromancy/Package/README.md
@@ -112,6 +112,7 @@ A. Put some Neck Tails inside it.
 
 Date | Version | Notes
 --- | --- | ---
+03/02/2023 | 1.6.5 | minions now remember the necromancy level with which they're created and scale to that; refactor SkeletonWand and DraugrWand code to be more uniform to make diffing easier; fix a bug where minions set to follow automatically would have bugged AI with the 1.6.4 improvements
 01/02/2023 | 1.6.4 | minions can be configured to drop their crafting requirements on death; hold position now works in that minions no longer wander around; wait positions are now recorded and stored so that minions return to where they were last waiting after chasing something off
 28/01/2023 | 1.6.3 | add optional timer to kill any minion after X seconds; overhaul minion ownership checks to accurately store and retrieve the minion's creator; minions will only obey commands from their creators and ignore others
 24/01/2023 | 1.6.2 | minions can be told to follow/wait using E on them; neckros can be killed via terminal command - butcher's knife won't work on them, even with Tameable component added, due to their Container component

--- a/ChebsNecromancy/Package/README.md
+++ b/ChebsNecromancy/Package/README.md
@@ -112,6 +112,7 @@ A. Put some Neck Tails inside it.
 
 Date | Version | Notes
 --- | --- | ---
+01/02/2023 | 1.6.4 | minions can be configured to drop their crafting requirements on death; hold position now works in that minions no longer wander around; wait positions are now recorded and stored so that minions return to where they were last waiting after chasing something off
 28/01/2023 | 1.6.3 | add optional timer to kill any minion after X seconds; overhaul minion ownership checks to accurately store and retrieve the minion's creator; minions will only obey commands from their creators and ignore others
 24/01/2023 | 1.6.2 | minions can be told to follow/wait using E on them; neckros can be killed via terminal command - butcher's knife won't work on them, even with Tameable component added, due to their Container component
 20/01/2023 | 1.6.1 | Fix a problem where the Neckro Gatherer could delete items without storing them if its inventory size is set very small like 1x1

--- a/ChebsNecromancy/Package/README.md
+++ b/ChebsNecromancy/Package/README.md
@@ -84,7 +84,8 @@ You can also edit the configs manually. Almost everything can be tweaked to your
 - Telling minions to attack what you're looking at (by spawning a big stone there - dumb but will be replaced with something more appropriate later)
 - Players with Radeon cards may experience weird issues. I don't know what's causing it, but turning off Draugr in the config may help because it seems related. If you encounter problems, try the following:
 	+ `DraugrAllowed = false`
-	+ `SpectralShroudSpawnWraith = false`
+	+ `SpectralShroudSpawnWraith = false`	
+- Pylons won't show inventory unless you open a normal container first.
 
 ## Future Ideas
 
@@ -111,6 +112,7 @@ You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
 Date | Version | Notes
 --- | --- | ---
+07/02/2023 | 1.7.4 | refueler pylons can now refuel fireplaces eg. torches, bonfires, etc.
 06/02/2023 | 1.7.3 | minions remember if they were following a player after player logs off, then continue following when player returns
 05/02/2023 | 1.7.2 | allow minions to roam when holding shift+T; fix bug in ZDO comparison
 05/02/2023 | 1.7.1 | allow admins to ignore ownership with commands; fix bug where players wouldnt be found by command; lint the entire project; catch and fix a few instances of MonoBehaviours accidently being instantiated with new -> a big no-no

--- a/ChebsNecromancy/Package/README.md
+++ b/ChebsNecromancy/Package/README.md
@@ -96,10 +96,13 @@ You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
 ## Special Thanks
 
-- **Dracbjorn** for development help & testing.
+- [**Dracbjorn**](https://github.com/Dracbjorn) for development help & testing.
 - **Ramblez** (aka **[Thorngor](https://www.nexusmods.com/users/21532784)** on the Nexus) for texturing help and for making the custom icons.
 - **redseiko** for helpful advice on the official Valheim modding Discord.
 - **S970X** for making the German language localization for the mod.
+- **Jetbrains** for kindly providing me with an [Open Source Development license](https://jb.gg/OpenSourceSupport) for their Rider product which makes development on this project smooth and easy.
+
+<img src="https://resources.jetbrains.com/storage/products/company/brand/logos/Rider.svg" alt="Rider logo." width=50% height=50%>
 
 ## Changelog
 
@@ -108,6 +111,8 @@ You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
 Date | Version | Notes
 --- | --- | ---
+06/02/2023 | 1.7.3 | minions remember if they were following a player after player logs off, then continue following when player returns
+05/02/2023 | 1.7.2 | allow minions to roam when holding shift+T; fix bug in ZDO comparison
 05/02/2023 | 1.7.1 | allow admins to ignore ownership with commands; fix bug where players wouldnt be found by command; lint the entire project; catch and fix a few instances of MonoBehaviours accidently being instantiated with new -> a big no-no
 03/02/2023 | 1.7.0 | minions now remember the necromancy level with which they're created and scale to that; refactor SkeletonWand and DraugrWand code to be more uniform to make diffing easier; fix a bug where minions set to follow automatically would have bugged AI with the 1.6.4 improvements; minion commandability exposed to config; commands issued via E also update ZDO; hover text for interact patched
 01/02/2023 | 1.6.4 | minions can be configured to drop their crafting requirements on death; hold position now works in that minions no longer wander around; wait positions are now recorded and stored so that minions return to where they were last waiting after chasing something off

--- a/ChebsNecromancy/Package/README.md
+++ b/ChebsNecromancy/Package/README.md
@@ -4,6 +4,8 @@ Cheb's Necromancy adds Necromancy to Valheim via craftable wands and structures.
 
 This mod was formerly called Friendly Skeleton Wand, but was renamed since it as grown into something so much more.
 
+## Confused? Try the [wiki](https://github.com/jpw1991/chebs-necromancy/wiki).
+
 **Pre-release versions:** To get the latest improvements but with less testing, check the [GitHub's releases page](https://github.com/jpw1991/chebs-necromancy/releases). Although less tested than the official releases, they are still tested pretty well.
 
 ##  About Me
@@ -75,35 +77,29 @@ Press **F1** to open the mod's configuration panel.
 
 You can also edit the configs manually. Almost everything can be tweaked to your liking.
 
-### F.A.Q
+## Known issues
 
-Q: How do I kill minions?
+- Skeletons can't follow you into/out of dungeons
+	+ This might be fixable via mods like **Teleport Everything** ([Nexus](https://www.nexusmods.com/valheim/mods/1806), [Thunderstore](https://valheim.thunderstore.io/package/OdinPlus/TeleportEverything/)).
+- Telling minions to attack what you're looking at (by spawning a big stone there - dumb but will be replaced with something more appropriate later)
+- Players with Radeon cards may experience weird issues. I don't know what's causing it, but turning off Draugr in the config may help because it seems related. If you encounter problems, try the following:
+	+ `DraugrAllowed = false`
+	+ `SpectralShroudSpawnWraith = false`
 
-A: They count as tames, so use butcher's knife
+## Future Ideas
 
-Q: What do minions eat?
+- Fully custom undead types.
 
-A: Nothing. They are just tames so that they earn you Necromancy XP and get a funny name.
+## Source
 
-Q: What meats work for spawning Draugr?
+You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
-A: Boar Meat, Neck Tail, Deer Meat, Lox Meat, Wolf Meat, Serpent Meat, Chicken Meat, Hare meat. It checks and consumes the first one it finds in that order - so low quality meats are preferred to high quality.
+## Special Thanks
 
-Q: Can I heal minions?
-
-A: Not yet, unless you use other mods that permit healing. I want to add healing eventually in some form.
-
-Q: How do I make a poison skeleton?
-
-A: Make sure your necromancy level is high enough and have some Guck in your inventory when creating a non-archer skeleton using the staff.
-
-Q: Can you add Frost Resistance to the Spectral Shroud and/or Necromancer Hood so I can use it in the Mountains?
-
-A: This is currently not planned because another mod called [Custom Armor Stats](https://www.nexusmods.com/valheim/mods/1162/) can be used to add it. So I'd rather spare myself the extra work.
-
-Q. How do I make the Neckro Gatherer Pylon work?
-
-A. Put some Neck Tails inside it.
+- **Dracbjorn** for development help & testing.
+- **Ramblez** (aka **[Thorngor](https://www.nexusmods.com/users/21532784)** on the Nexus) for texturing help and for making the custom icons.
+- **redseiko** for helpful advice on the official Valheim modding Discord.
+- **S970X** for making the German language localization for the mod.
 
 ## Changelog
 
@@ -112,7 +108,7 @@ A. Put some Neck Tails inside it.
 
 Date | Version | Notes
 --- | --- | ---
-03/02/2023 | 1.6.5 | minions now remember the necromancy level with which they're created and scale to that; refactor SkeletonWand and DraugrWand code to be more uniform to make diffing easier; fix a bug where minions set to follow automatically would have bugged AI with the 1.6.4 improvements
+03/02/2023 | 1.7.0 | minions now remember the necromancy level with which they're created and scale to that; refactor SkeletonWand and DraugrWand code to be more uniform to make diffing easier; fix a bug where minions set to follow automatically would have bugged AI with the 1.6.4 improvements; minion commandability exposed to config; commands issued via E also update ZDO; hover text for interact patched
 01/02/2023 | 1.6.4 | minions can be configured to drop their crafting requirements on death; hold position now works in that minions no longer wander around; wait positions are now recorded and stored so that minions return to where they were last waiting after chasing something off
 28/01/2023 | 1.6.3 | add optional timer to kill any minion after X seconds; overhaul minion ownership checks to accurately store and retrieve the minion's creator; minions will only obey commands from their creators and ignore others
 24/01/2023 | 1.6.2 | minions can be told to follow/wait using E on them; neckros can be killed via terminal command - butcher's knife won't work on them, even with Tameable component added, due to their Container component
@@ -164,27 +160,4 @@ Date | Version | Notes
 25/11/2022 | 1.0.0 | Release
 
 </details>
-
-## Known issues
-
-- Skeletons can't follow you into/out of dungeons
-- Telling minions to attack what you're looking at (by spawning a big stone there - dumb but will be replaced with something more appropriate later)
-- Players with Radeon cards may experience weird issues. I don't know what's causing it, but turning off Draugr in the config may help because it seems related. If you encounter problems, try the following:
-  - `DraugrAllowed = false`
-  - `SpectralShroudSpawnWraith = false`
-
-## Future Ideas
-
-- Fully custom undead types.
-
-## Source
-
-You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
-
-## Special Thanks
-
-- **Dracbjorn** for development help & testing.
-- **Ramblez** (aka **[Thorngor](https://www.nexusmods.com/users/21532784)** on the Nexus) for texturing help and for making the custom icons.
-- **redseiko** for helpful advice on the official Valheim modding Discord.
-- **S970X** for making the German language localization for the mod.
 

--- a/ChebsNecromancy/Package/manifest.json
+++ b/ChebsNecromancy/Package/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "name": "ChebsNecromancy",
   "description": "Cheb's Necromancy adds Necromancy to Valheim via craftable wands and structures. Minions will follow you, guard your base, and perform menial tasks.",
-  "version_number": "1.7.3",
+  "version_number": "1.7.4",
   "website_url": "https://github.com/jpw1991/chebs-necromancy",
   "dependencies": [
     "ValheimModding-Jotunn-2.10.4"

--- a/ChebsNecromancy/Package/manifest.json
+++ b/ChebsNecromancy/Package/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "name": "ChebsNecromancy",
   "description": "Cheb's Necromancy adds Necromancy to Valheim via craftable wands and structures. Minions will follow you, guard your base, and perform menial tasks.",
-  "version_number": "1.7.2",
+  "version_number": "1.7.3",
   "website_url": "https://github.com/jpw1991/chebs-necromancy",
   "dependencies": [
     "ValheimModding-Jotunn-2.10.4"

--- a/ChebsNecromancy/Package/manifest.json
+++ b/ChebsNecromancy/Package/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "name": "ChebsNecromancy",
   "description": "Cheb's Necromancy adds Necromancy to Valheim via craftable wands and structures. Minions will follow you, guard your base, and perform menial tasks.",
-  "version_number": "1.6.5",
+  "version_number": "1.7.0",
   "website_url": "https://github.com/jpw1991/chebs-necromancy",
   "dependencies": [
     "ValheimModding-Jotunn-2.10.0"

--- a/ChebsNecromancy/Package/manifest.json
+++ b/ChebsNecromancy/Package/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "name": "ChebsNecromancy",
   "description": "Cheb's Necromancy adds Necromancy to Valheim via craftable wands and structures. Minions will follow you, guard your base, and perform menial tasks.",
-  "version_number": "1.7.5",
+  "version_number": "1.7.6",
   "website_url": "https://github.com/jpw1991/chebs-necromancy",
   "dependencies": [
     "ValheimModding-Jotunn-2.10.4"

--- a/ChebsNecromancy/Package/manifest.json
+++ b/ChebsNecromancy/Package/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "name": "ChebsNecromancy",
   "description": "Cheb's Necromancy adds Necromancy to Valheim via craftable wands and structures. Minions will follow you, guard your base, and perform menial tasks.",
-  "version_number": "1.7.6",
+  "version_number": "1.7.7",
   "website_url": "https://github.com/jpw1991/chebs-necromancy",
   "dependencies": [
     "ValheimModding-Jotunn-2.10.4"

--- a/ChebsNecromancy/Package/manifest.json
+++ b/ChebsNecromancy/Package/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "name": "ChebsNecromancy",
   "description": "Cheb's Necromancy adds Necromancy to Valheim via craftable wands and structures. Minions will follow you, guard your base, and perform menial tasks.",
-  "version_number": "1.7.1",
+  "version_number": "1.7.2",
   "website_url": "https://github.com/jpw1991/chebs-necromancy",
   "dependencies": [
     "ValheimModding-Jotunn-2.10.4"

--- a/ChebsNecromancy/Package/manifest.json
+++ b/ChebsNecromancy/Package/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "name": "ChebsNecromancy",
   "description": "Cheb's Necromancy adds Necromancy to Valheim via craftable wands and structures. Minions will follow you, guard your base, and perform menial tasks.",
-  "version_number": "1.7.4",
+  "version_number": "1.7.5",
   "website_url": "https://github.com/jpw1991/chebs-necromancy",
   "dependencies": [
     "ValheimModding-Jotunn-2.10.4"

--- a/ChebsNecromancy/Package/manifest.json
+++ b/ChebsNecromancy/Package/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "name": "ChebsNecromancy",
   "description": "Cheb's Necromancy adds Necromancy to Valheim via craftable wands and structures. Minions will follow you, guard your base, and perform menial tasks.",
-  "version_number": "1.6.4",
+  "version_number": "1.6.5",
   "website_url": "https://github.com/jpw1991/chebs-necromancy",
   "dependencies": [
     "ValheimModding-Jotunn-2.10.0"

--- a/ChebsNecromancy/Structures/BatBeacon.cs
+++ b/ChebsNecromancy/Structures/BatBeacon.cs
@@ -1,9 +1,11 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using BepInEx.Configuration;
 using ChebsNecromancy.Common;
 using UnityEngine;
+using Logger = Jotunn.Logger;
 
 namespace ChebsNecromancy.Structures
 {
@@ -26,7 +28,7 @@ namespace ChebsNecromancy.Structures
             PieceName = "$chebgonaz_batbeacon_name",
             PieceDescription = "$chebgonaz_batbeacon_desc",
             PrefabName = "ChebGonaz_BatBeacon.prefab",
-            ObjectName = System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Name
+            ObjectName = MethodBase.GetCurrentMethod().DeclaringType.Name
         };
 
         public static void CreateConfigs(BasePlugin plugin)
@@ -127,7 +129,7 @@ namespace ChebsNecromancy.Structures
             GameObject prefab = ZNetScene.instance.GetPrefab(prefabName);
             if (!prefab)
             {
-                Jotunn.Logger.LogError($"spawning {prefabName} failed!");
+                Logger.LogError($"spawning {prefabName} failed!");
                 return null;
             }
 

--- a/ChebsNecromancy/Structures/NeckroGathererPylon.cs
+++ b/ChebsNecromancy/Structures/NeckroGathererPylon.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using BepInEx.Configuration;
 using ChebsNecromancy.Common;
+using ChebsNecromancy.Minions;
 using UnityEngine;
 using Logger = Jotunn.Logger;
 
@@ -68,10 +69,18 @@ namespace ChebsNecromancy.Structures
             }
         }
 
-        protected GameObject SpawnNeckro()
+        protected void SpawnNeckro()
         {
+            // find nearest player and make them the owner
+            var player = Player.GetClosestPlayer(transform.position, NeckroGathererMinion.LookRadius.Value);
+            if (!player)
+            {
+                // no master? no neckro
+                return;
+            }
+            
             int neckTailsInInventory = Container.GetInventory().CountItems("$item_necktail");
-            if (neckTailsInInventory < NeckTailsConsumedPerSpawn.Value) return null;
+            if (neckTailsInInventory < NeckTailsConsumedPerSpawn.Value) return;
 
             Container.GetInventory().RemoveItem("$item_necktail", NeckTailsConsumedPerSpawn.Value);
 
@@ -82,7 +91,7 @@ namespace ChebsNecromancy.Structures
             if (!prefab)
             {
                 Logger.LogError($"spawning {prefabName} failed!");
-                return null;
+                return;
             }
 
             GameObject spawnedChar = Instantiate(
@@ -92,8 +101,8 @@ namespace ChebsNecromancy.Structures
 
             Character character = spawnedChar.GetComponent<Character>();
             character.SetLevel(quality);
-
-            return spawnedChar;
+            
+            spawnedChar.GetComponent<NeckroGathererMinion>().SetUndeadMinionMaster(player.GetPlayerName());
         }
     }
 }

--- a/ChebsNecromancy/Structures/NeckroGathererPylon.cs
+++ b/ChebsNecromancy/Structures/NeckroGathererPylon.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Reflection;
 using BepInEx.Configuration;
 using ChebsNecromancy.Common;
 using UnityEngine;
@@ -22,7 +23,7 @@ namespace ChebsNecromancy.Structures
             PieceName = "$chebgonaz_neckrogathererpylon_name",
             PieceDescription = "$chebgonaz_neckrogathererpylon_desc",
             PrefabName = "ChebGonaz_NeckroGathererPylon.prefab",
-            ObjectName = System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Name
+            ObjectName = MethodBase.GetCurrentMethod().DeclaringType.Name
         };
 
         public static void CreateConfigs(BasePlugin plugin)

--- a/ChebsNecromancy/Structures/NeckroGathererPylon.cs
+++ b/ChebsNecromancy/Structures/NeckroGathererPylon.cs
@@ -7,7 +7,7 @@ using Jotunn.Entities;
 using UnityEngine;
 using Logger = Jotunn.Logger;
 
-namespace ChebsNecromancy.Minions
+namespace ChebsNecromancy.Structures
 {
     internal class NeckroGathererPylon : MonoBehaviour
     {

--- a/ChebsNecromancy/Structures/RefuelerPylon.cs
+++ b/ChebsNecromancy/Structures/RefuelerPylon.cs
@@ -9,7 +9,7 @@ using Jotunn.Entities;
 using UnityEngine;
 using Logger = Jotunn.Logger;
 
-namespace ChebsNecromancy.Minions
+namespace ChebsNecromancy.Structures
 {
     internal class RefuelerPylon : MonoBehaviour
     {

--- a/ChebsNecromancy/Structures/RefuelerPylon.cs
+++ b/ChebsNecromancy/Structures/RefuelerPylon.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
+using System.Reflection;
 using BepInEx.Configuration;
 using ChebsNecromancy.Common;
 using UnityEngine;
@@ -27,7 +27,7 @@ namespace ChebsNecromancy.Structures
             PieceName = "$chebgonaz_refuelerpylon_name",
             PieceDescription = "$chebgonaz_refuelerpylon_desc",
             PrefabName = "ChebGonaz_RefuelerPylon.prefab",
-            ObjectName = System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Name
+            ObjectName = MethodBase.GetCurrentMethod().DeclaringType.Name
         };
 
         public static void CreateConfigs(BasePlugin plugin)

--- a/ChebsNecromancy/Structures/SpiritPylon.cs
+++ b/ChebsNecromancy/Structures/SpiritPylon.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.AccessControl;
+using System.Reflection;
 using BepInEx.Configuration;
 using ChebsNecromancy.Common;
 using UnityEngine;
@@ -28,7 +28,7 @@ namespace ChebsNecromancy.Structures
             PieceName = "$chebgonaz_spiritpylon_name",
             PieceDescription = "$chebgonaz_spiritpylon_desc",
             PrefabName = "ChebGonaz_SpiritPylon.prefab",
-            ObjectName = System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Name
+            ObjectName = MethodBase.GetCurrentMethod().DeclaringType.Name
     };
 
         public static void CreateConfigs(BasePlugin plugin)

--- a/ChebsNecromancy/packages.config
+++ b/ChebsNecromancy/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="HarmonyX" version="2.10.1" targetFramework="net48" />
-  <package id="JotunnLib" version="2.10.3" targetFramework="net48" />
+  <package id="JotunnLib" version="2.10.4" targetFramework="net48" />
   <package id="Mono.Cecil" version="0.11.4" targetFramework="net462" />
   <package id="MonoMod" version="22.7.31.1" targetFramework="net48" />
   <package id="MonoMod.RuntimeDetour" version="22.7.31.1" targetFramework="net48" />

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
 Date | Version | Notes
 --- | --- | ---
+09/02/2023 | 1.7.5 | Neckro messages hideable; Neckro messages improved
 07/02/2023 | 1.7.4 | refueler pylons can now refuel fireplaces eg. torches, bonfires, etc.
 06/02/2023 | 1.7.3 | minions remember if they were following a player after player logs off, then continue following when player returns
 05/02/2023 | 1.7.2 | allow minions to roam when holding shift+T; fix bug in ZDO comparison

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
 Date | Version | Notes
 --- | --- | ---
+10/02/2023 | 1.7.6 | Dracbjorn's config overhaul; optimise imports
 09/02/2023 | 1.7.5 | Neckro messages hideable; Neckro messages improved
 07/02/2023 | 1.7.4 | refueler pylons can now refuel fireplaces eg. torches, bonfires, etc.
 06/02/2023 | 1.7.3 | minions remember if they were following a player after player logs off, then continue following when player returns

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
 Date | Version | Notes
 --- | --- | ---
+11/02/2023 | 1.7.7 | Neckro pylons only spawn neckros if a player is nearby and that player takes ownership of the Neckro; fix bug that permitted non-admins to use some commands; optimise draugr & skeleton Awake scaling
 10/02/2023 | 1.7.6 | Dracbjorn's config overhaul; optimise imports
 09/02/2023 | 1.7.5 | Neckro messages hideable; Neckro messages improved
 07/02/2023 | 1.7.4 | refueler pylons can now refuel fireplaces eg. torches, bonfires, etc.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
 Date | Version | Notes
 --- | --- | ---
-04/02/2023 | 1.7.1 | lint the entire project; catch and fix a few instances of MonoBehaviours accidently being instantiated with new -> a big no-no
+05/02/2023 | 1.7.1 | allow admins to ignore ownership with commands; fix bug where players wouldnt be found by command; lint the entire project; catch and fix a few instances of MonoBehaviours accidently being instantiated with new -> a big no-no
 03/02/2023 | 1.7.0 | minions now remember the necromancy level with which they're created and scale to that; refactor SkeletonWand and DraugrWand code to be more uniform to make diffing easier; fix a bug where minions set to follow automatically would have bugged AI with the 1.6.4 improvements; minion commandability exposed to config; commands issued via E also update ZDO; hover text for interact patched
 01/02/2023 | 1.6.4 | minions can be configured to drop their crafting requirements on death; hold position now works in that minions no longer wander around; wait positions are now recorded and stored so that minions return to where they were last waiting after chasing something off
 28/01/2023 | 1.6.3 | add optional timer to kill any minion after X seconds; overhaul minion ownership checks to accurately store and retrieve the minion's creator; minions will only obey commands from their creators and ignore others

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ A. Put some Neck Tails inside it.
 
 Date | Version | Notes
 --- | --- | ---
+03/02/2023 | 1.6.5 | minions now remember the necromancy level with which they're created and scale to that; refactor SkeletonWand and DraugrWand code to be more uniform to make diffing easier; fix a bug where minions set to follow automatically would have bugged AI with the 1.6.4 improvements
 01/02/2023 | 1.6.4 | minions can be configured to drop their crafting requirements on death; hold position now works in that minions no longer wander around; wait positions are now recorded and stored so that minions return to where they were last waiting after chasing something off
 28/01/2023 | 1.6.3 | add optional timer to kill any minion after X seconds; overhaul minion ownership checks to accurately store and retrieve the minion's creator; minions will only obey commands from their creators and ignore others
 24/01/2023 | 1.6.2 | minions can be told to follow/wait using E on them; neckros can be killed via terminal command - butcher's knife won't work on them, even with Tameable component added, due to their Container component

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ You can also edit the configs manually. Almost everything can be tweaked to your
 - Telling minions to attack what you're looking at (by spawning a big stone there - dumb but will be replaced with something more appropriate later)
 - Players with Radeon cards may experience weird issues. I don't know what's causing it, but turning off Draugr in the config may help because it seems related. If you encounter problems, try the following:
 	+ `DraugrAllowed = false`
-	+ `SpectralShroudSpawnWraith = false`
+	+ `SpectralShroudSpawnWraith = false`	
+- Pylons won't show inventory unless you open a normal container first.
 
 ## Future Ideas
 
@@ -111,6 +112,7 @@ You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
 Date | Version | Notes
 --- | --- | ---
+07/02/2023 | 1.7.4 | refueler pylons can now refuel fireplaces eg. torches, bonfires, etc.
 06/02/2023 | 1.7.3 | minions remember if they were following a player after player logs off, then continue following when player returns
 05/02/2023 | 1.7.2 | allow minions to roam when holding shift+T; fix bug in ZDO comparison
 05/02/2023 | 1.7.1 | allow admins to ignore ownership with commands; fix bug where players wouldnt be found by command; lint the entire project; catch and fix a few instances of MonoBehaviours accidently being instantiated with new -> a big no-no

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ A. Put some Neck Tails inside it.
 
 Date | Version | Notes
 --- | --- | ---
-03/02/2023 | 1.6.5 | minions now remember the necromancy level with which they're created and scale to that; refactor SkeletonWand and DraugrWand code to be more uniform to make diffing easier; fix a bug where minions set to follow automatically would have bugged AI with the 1.6.4 improvements
+03/02/2023 | 1.6.5 | minions now remember the necromancy level with which they're created and scale to that; refactor SkeletonWand and DraugrWand code to be more uniform to make diffing easier; fix a bug where minions set to follow automatically would have bugged AI with the 1.6.4 improvements; minion commandability exposed to config; commands issued via E also update ZDO; hover text for interact patched
 01/02/2023 | 1.6.4 | minions can be configured to drop their crafting requirements on death; hold position now works in that minions no longer wander around; wait positions are now recorded and stored so that minions return to where they were last waiting after chasing something off
 28/01/2023 | 1.6.3 | add optional timer to kill any minion after X seconds; overhaul minion ownership checks to accurately store and retrieve the minion's creator; minions will only obey commands from their creators and ignore others
 24/01/2023 | 1.6.2 | minions can be told to follow/wait using E on them; neckros can be killed via terminal command - butcher's knife won't work on them, even with Tameable component added, due to their Container component

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
 Date | Version | Notes
 --- | --- | ---
+06/02/2023 | 1.7.3 | minions remember if they were following a player after player logs off, then continue following when player returns
+05/02/2023 | 1.7.2 | allow minions to roam when holding shift+T; fix bug in ZDO comparison
 05/02/2023 | 1.7.1 | allow admins to ignore ownership with commands; fix bug where players wouldnt be found by command; lint the entire project; catch and fix a few instances of MonoBehaviours accidently being instantiated with new -> a big no-no
 03/02/2023 | 1.7.0 | minions now remember the necromancy level with which they're created and scale to that; refactor SkeletonWand and DraugrWand code to be more uniform to make diffing easier; fix a bug where minions set to follow automatically would have bugged AI with the 1.6.4 improvements; minion commandability exposed to config; commands issued via E also update ZDO; hover text for interact patched
 01/02/2023 | 1.6.4 | minions can be configured to drop their crafting requirements on death; hold position now works in that minions no longer wander around; wait positions are now recorded and stored so that minions return to where they were last waiting after chasing something off

--- a/README.md
+++ b/README.md
@@ -96,10 +96,13 @@ You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
 ## Special Thanks
 
-- **Dracbjorn** for development help & testing.
+- [**Dracbjorn**](https://github.com/Dracbjorn) for development help & testing.
 - **Ramblez** (aka **[Thorngor](https://www.nexusmods.com/users/21532784)** on the Nexus) for texturing help and for making the custom icons.
 - **redseiko** for helpful advice on the official Valheim modding Discord.
 - **S970X** for making the German language localization for the mod.
+- **Jetbrains** for kindly providing me with an [Open Source Development license](https://jb.gg/OpenSourceSupport) for their Rider product which makes development on this project smooth and easy.
+
+<img src="https://resources.jetbrains.com/storage/products/company/brand/logos/Rider.svg" alt="Rider logo." width=50% height=50%>
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Cheb's Necromancy adds Necromancy to Valheim via craftable wands and structures.
 
 This mod was formerly called Friendly Skeleton Wand, but was renamed since it as grown into something so much more.
 
+## Confused? Try the [wiki](https://github.com/jpw1991/chebs-necromancy/wiki).
+
 **Pre-release versions:** To get the latest improvements but with less testing, check the [GitHub's releases page](https://github.com/jpw1991/chebs-necromancy/releases). Although less tested than the official releases, they are still tested pretty well.
 
 ##  About Me
@@ -75,35 +77,29 @@ Press **F1** to open the mod's configuration panel.
 
 You can also edit the configs manually. Almost everything can be tweaked to your liking.
 
-### F.A.Q
+## Known issues
 
-Q: How do I kill minions?
+- Skeletons can't follow you into/out of dungeons
+	+ This might be fixable via mods like **Teleport Everything** ([Nexus](https://www.nexusmods.com/valheim/mods/1806), [Thunderstore](https://valheim.thunderstore.io/package/OdinPlus/TeleportEverything/)).
+- Telling minions to attack what you're looking at (by spawning a big stone there - dumb but will be replaced with something more appropriate later)
+- Players with Radeon cards may experience weird issues. I don't know what's causing it, but turning off Draugr in the config may help because it seems related. If you encounter problems, try the following:
+	+ `DraugrAllowed = false`
+	+ `SpectralShroudSpawnWraith = false`
 
-A: They count as tames, so use butcher's knife
+## Future Ideas
 
-Q: What do minions eat?
+- Fully custom undead types.
 
-A: Nothing. They are just tames so that they earn you Necromancy XP and get a funny name.
+## Source
 
-Q: What meats work for spawning Draugr?
+You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
-A: Boar Meat, Neck Tail, Deer Meat, Lox Meat, Wolf Meat, Serpent Meat, Chicken Meat, Hare meat. It checks and consumes the first one it finds in that order - so low quality meats are preferred to high quality.
+## Special Thanks
 
-Q: Can I heal minions?
-
-A: Not yet, unless you use other mods that permit healing. I want to add healing eventually in some form.
-
-Q: How do I make a poison skeleton?
-
-A: Make sure your necromancy level is high enough and have some Guck in your inventory when creating a non-archer skeleton using the staff.
-
-Q: Can you add Frost Resistance to the Spectral Shroud and/or Necromancer Hood so I can use it in the Mountains?
-
-A: This is currently not planned because another mod called [Custom Armor Stats](https://www.nexusmods.com/valheim/mods/1162/) can be used to add it. So I'd rather spare myself the extra work.
-
-Q. How do I make the Neckro Gatherer Pylon work?
-
-A. Put some Neck Tails inside it.
+- **Dracbjorn** for development help & testing.
+- **Ramblez** (aka **[Thorngor](https://www.nexusmods.com/users/21532784)** on the Nexus) for texturing help and for making the custom icons.
+- **redseiko** for helpful advice on the official Valheim modding Discord.
+- **S970X** for making the German language localization for the mod.
 
 ## Changelog
 
@@ -112,7 +108,7 @@ A. Put some Neck Tails inside it.
 
 Date | Version | Notes
 --- | --- | ---
-03/02/2023 | 1.6.5 | minions now remember the necromancy level with which they're created and scale to that; refactor SkeletonWand and DraugrWand code to be more uniform to make diffing easier; fix a bug where minions set to follow automatically would have bugged AI with the 1.6.4 improvements; minion commandability exposed to config; commands issued via E also update ZDO; hover text for interact patched
+03/02/2023 | 1.7.0 | minions now remember the necromancy level with which they're created and scale to that; refactor SkeletonWand and DraugrWand code to be more uniform to make diffing easier; fix a bug where minions set to follow automatically would have bugged AI with the 1.6.4 improvements; minion commandability exposed to config; commands issued via E also update ZDO; hover text for interact patched
 01/02/2023 | 1.6.4 | minions can be configured to drop their crafting requirements on death; hold position now works in that minions no longer wander around; wait positions are now recorded and stored so that minions return to where they were last waiting after chasing something off
 28/01/2023 | 1.6.3 | add optional timer to kill any minion after X seconds; overhaul minion ownership checks to accurately store and retrieve the minion's creator; minions will only obey commands from their creators and ignore others
 24/01/2023 | 1.6.2 | minions can be told to follow/wait using E on them; neckros can be killed via terminal command - butcher's knife won't work on them, even with Tameable component added, due to their Container component
@@ -164,27 +160,4 @@ Date | Version | Notes
 25/11/2022 | 1.0.0 | Release
 
 </details>
-
-## Known issues
-
-- Skeletons can't follow you into/out of dungeons
-- Telling minions to attack what you're looking at (by spawning a big stone there - dumb but will be replaced with something more appropriate later)
-- Players with Radeon cards may experience weird issues. I don't know what's causing it, but turning off Draugr in the config may help because it seems related. If you encounter problems, try the following:
-  - `DraugrAllowed = false`
-  - `SpectralShroudSpawnWraith = false`
-
-## Future Ideas
-
-- Fully custom undead types.
-
-## Source
-
-You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
-
-## Special Thanks
-
-- **Dracbjorn** for development help & testing.
-- **Ramblez** (aka **[Thorngor](https://www.nexusmods.com/users/21532784)** on the Nexus) for texturing help and for making the custom icons.
-- **redseiko** for helpful advice on the official Valheim modding Discord.
-- **S970X** for making the German language localization for the mod.
 

--- a/publish.sh
+++ b/publish.sh
@@ -74,6 +74,9 @@ if [ $TARGET == "Release" ]; then
   cp "$TARGETPATH/$TARGETASSEMBLY" "$packagePath/plugins/$name"
   cp "README.md" "$packagePath"
   cp -r "$PROJECTPATH/$name/Assets" "$packagePath/plugins/$name"
+  if [ ! -z "$VERSION" ]; then
+    VERSION=".$VERSION"
+  fi
   zipLocation="$TARGETPATH/$TARGETASSEMBLY$VERSION.zip"
   echo "Zipping to $PROJECTPATH/$zipLocation"
   cd $packagePath


### PR DESCRIPTION
# Pre-compiled

You can get 1.7.3 here to test with https://github.com/jpw1991/chebs-necromancy/releases/tag/1.7.3

# Description

- RoamRange exposed to config
- Using Shift+T on following minions permits them to roam
- Minions remember if they were following a player and continue following when the player logs back in
- 1.7.4: refueler pylons now also refuel fireplaces eg. torches, bonfires, etc. No need to test this one if you don't want to. Already did lots
- 1.7.5: Neckro messages hideable; Neckro messages improved

## Testing

- Ensure that Wait works like before (also on logout/login)
- Ensure that Follow works like before (also on logout/login)
- Ensure that Roam works and that it is remembered on logout/login
- Ensure that minions following the player when player logs off continue following the player after player logs back in