### PR TITLE
2.3.5: guardian wraith shouldn't drop fragments anymore

### DIFF
--- a/ChebsNecromancy/BasePlugin.cs
+++ b/ChebsNecromancy/BasePlugin.cs
@@ -31,7 +31,7 @@ namespace ChebsNecromancy
     {
         public const string PluginGuid = "com.chebgonaz.ChebsNecromancy";
         public const string PluginName = "ChebsNecromancy";
-        public const string PluginVersion = "2.3.4";
+        public const string PluginVersion = "2.3.5";
         private const string ConfigFileName =  PluginGuid + ".cfg";
         private static readonly string ConfigFileFullPath = Path.Combine(Paths.ConfigPath, ConfigFileName);
 

--- a/ChebsNecromancy/Package/manifest.json
+++ b/ChebsNecromancy/Package/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "name": "ChebsNecromancy",
   "description": "Cheb's Necromancy adds Necromancy to Valheim via craftable wands and structures. Minions will follow you, guard your base, and perform menial tasks.",
-  "version_number": "2.3.4",
+  "version_number": "2.3.5",
   "website_url": "https://github.com/jpw1991/chebs-necromancy",
   "dependencies": [
     "ValheimModding-Jotunn-2.10.4"

--- a/ChebsNecromancy/Patches/CharacterDropPatches.cs
+++ b/ChebsNecromancy/Patches/CharacterDropPatches.cs
@@ -22,10 +22,13 @@ namespace ChebsNecromancy.Patches
     class CharacterDrop_Patches
     {
         [HarmonyPrefix]
-        static void AddBonesToDropList(ref List<CharacterDrop.Drop> ___m_drops)
+        static void AddBonesToDropList(ref List<CharacterDrop.Drop> ___m_drops, CharacterDrop __instance)
         {
             if (BasePlugin.BoneFragmentsDroppedAmountMin.Value >= 0
-                && BasePlugin.BoneFragmentsDroppedAmountMax.Value > 0)
+                && BasePlugin.BoneFragmentsDroppedAmountMax.Value > 0
+                // for some stupid reason, the GuardianWraith somehow drops bones even though it shouldn't even have
+                // a CharacterDrop component on it. I guess somehow it's being added on. Just ignore it
+                && !__instance.TryGetComponent(out GuardianWraithMinion _))
             {
                 CharacterDrop.Drop bones = new()
                 {


### PR DESCRIPTION
- [ ] Check that when a guardian wraith dies, it never drops bone fragments (for easier testing, set bone drop chance to 100% in config)

Compiled version [here](https://github.com/jpw1991/chebs-necromancy/releases/tag/2.3.5)