### PR TITLE
2.5.9: fix a null object exception for structure friendly-fire code; …

### DIFF
--- a/ChebsNecromancy/Assets/chebgonaz.manifest
+++ b/ChebsNecromancy/Assets/chebgonaz.manifest
@@ -1,9 +1,9 @@
 ManifestFileVersion: 0
-CRC: 3397770505
+CRC: 1080411948
 Hashes:
   AssetFileHash:
     serializedVersion: 2
-    Hash: 3468dcdcc05d08b062af4ea18d16b2ce
+    Hash: 0c3f72a0f65842b09990bd5fba4bab92
   TypeTreeHash:
     serializedVersion: 2
     Hash: f217880939f95309b92eb737385684c4
@@ -283,12 +283,11 @@ Assets:
 - Assets/_ChebGonaz/BlackIronArmor/ChebGonaz_HelmetBlackIron.prefab
 - Assets/_ChebGonaz/TreasurePylon/ChebGonaz_TreasurePylon.prefab
 - Assets/_ChebGonaz/SkeletonMage/ChebGonaz_FireballProjectileGoblin.prefab
-- Assets/_ChebGonaz/SkeletonMiner/ChebGonaz_PickaxeProjectile.prefab
 - Assets/_ChebGonaz/SkeletonArcher/ChebGonaz_SkeletonArcherFire.prefab
+- Assets/_ChebGonaz/Neckro/ChebGonaz_NeckroGathererPylon.mat
 - Assets/_ChebGonaz/UndeadWeapons/ChebGonaz_SkeletonMace.prefab
 - Assets/_ChebGonaz/UndeadWeapons/ChebGonaz_SkeletonClub.prefab
 - Assets/_ChebGonaz/NecromancerCape/ChebGonaz_NecromancerCapeAzathoth.mat
-- Assets/_ChebGonaz/Neckro/ChebGonaz_NeckroGathererPylon.mat
 - Assets/_ChebGonaz/Draugr/ChebGonaz_DraugrWarriorNeedle.prefab
 - Assets/_ChebGonaz/NecromancerCape/ChebGonaz_NecromancerCapeCthulhu.mat
 - Assets/_ChebGonaz/LeatherArmors/Lox/ChebGonaz_SkeletonHelmetLeatherPoisonLox.prefab

--- a/ChebsNecromancy/BasePlugin.cs
+++ b/ChebsNecromancy/BasePlugin.cs
@@ -34,7 +34,7 @@ namespace ChebsNecromancy
     {
         public const string PluginGuid = "com.chebgonaz.ChebsNecromancy";
         public const string PluginName = "ChebsNecromancy";
-        public const string PluginVersion = "2.5.8";
+        public const string PluginVersion = "2.5.9";
         private const string ConfigFileName =  PluginGuid + ".cfg";
         private static readonly string ConfigFileFullPath = Path.Combine(Paths.ConfigPath, ConfigFileName);
 

--- a/ChebsNecromancy/ChebsNecromancy.csproj
+++ b/ChebsNecromancy/ChebsNecromancy.csproj
@@ -189,6 +189,7 @@
     <Compile Include="Minions\SkeletonWoodcutterMinion.cs" />
     <Compile Include="Common\ChebsRecipe.cs" />
     <Compile Include="Patches\AoePatches.cs" />
+    <Compile Include="Patches\ImpactEffectPatches.cs" />
     <Compile Include="Patches\PlayerPatches.cs" />
     <Compile Include="Patches\BaseAIPatches.cs" />
     <Compile Include="Patches\CharacterDropPatches.cs" />

--- a/ChebsNecromancy/Items/Wands/DraugrWand.cs
+++ b/ChebsNecromancy/Items/Wands/DraugrWand.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using BepInEx;
 using BepInEx.Configuration;
 using ChebsNecromancy.Minions;
@@ -658,123 +657,63 @@ namespace ChebsNecromancy.Items
             minion.UndeadMinionMaster = player.GetPlayerName();
 
             // handle refunding of resources on death
-            if (DraugrMinion.DropOnDeath.Value != UndeadMinion.DropType.Nothing)
+            if (DraugrMinion.DropOnDeath.Value == UndeadMinion.DropType.Nothing) return;
+            
+            // we have to be a little bit cautious. It normally shouldn't exist yet, but maybe some other mod
+            // added it? Who knows
+            var characterDrop = minion.gameObject.GetComponent<CharacterDrop>();
+            if (characterDrop == null)
             {
-                CharacterDrop characterDrop = minion.gameObject.AddComponent<CharacterDrop>();
-
-                if (DraugrMinion.DropOnDeath.Value == UndeadMinion.DropType.Everything)
-                {
-                    // bones
-                    if (DraugrBoneFragmentsRequiredConfig.Value > 0)
-                    {
-                        characterDrop.m_drops.Add(new CharacterDrop.Drop
-                        {
-                            m_prefab = ZNetScene.instance.GetPrefab("BoneFragments"),
-                            m_onePerPlayer = true,
-                            m_amountMin = DraugrBoneFragmentsRequiredConfig.Value,
-                            m_amountMax = DraugrBoneFragmentsRequiredConfig.Value,
-                            m_chance = 1f
-                        });
-                    }
-
-                    // meat. For now, assume Neck tails
-                    if (DraugrMeatRequiredConfig.Value > 0)
-                    {
-                        characterDrop.m_drops.Add(new CharacterDrop.Drop
-                        {
-                            m_prefab = ZNetScene.instance.GetPrefab("NeckTail"),
-                            m_onePerPlayer = true,
-                            m_amountMin = DraugrMeatRequiredConfig.Value,
-                            m_amountMax = DraugrMeatRequiredConfig.Value,
-                            m_chance = 1f
-                        });
-                    }
-                }
-
-                switch (armorType)
-                {
-                    case UndeadMinion.ArmorType.Leather:
-                        characterDrop.m_drops.Add(new CharacterDrop.Drop
-                        {
-                            // flip a coin for deer or scraps
-                            m_prefab = Random.value > .5f 
-                                ? ZNetScene.instance.GetPrefab("DeerHide")
-                                : ZNetScene.instance.GetPrefab("LeatherScraps") 
-                            ,
-                            m_onePerPlayer = true,
-                            m_amountMin = BasePlugin.ArmorLeatherScrapsRequiredConfig.Value,
-                            m_amountMax = BasePlugin.ArmorLeatherScrapsRequiredConfig.Value,
-                            m_chance = 1f
-                        });
-                        break;
-                    case UndeadMinion.ArmorType.LeatherTroll:
-                        characterDrop.m_drops.Add(new CharacterDrop.Drop
-                        {
-                            m_prefab = ZNetScene.instance.GetPrefab("TrollHide"),
-                            m_onePerPlayer = true,
-                            m_amountMin = BasePlugin.ArmorBronzeRequiredConfig.Value,
-                            m_amountMax = BasePlugin.ArmorBronzeRequiredConfig.Value,
-                            m_chance = 1f
-                        });
-                        break;
-                    case UndeadMinion.ArmorType.LeatherWolf:
-                        characterDrop.m_drops.Add(new CharacterDrop.Drop
-                        {
-                            m_prefab = ZNetScene.instance.GetPrefab("WolfPelt"),
-                            m_onePerPlayer = true,
-                            m_amountMin = BasePlugin.ArmorBronzeRequiredConfig.Value,
-                            m_amountMax = BasePlugin.ArmorBronzeRequiredConfig.Value,
-                            m_chance = 1f
-                        });
-                        break;
-                    case UndeadMinion.ArmorType.LeatherLox:
-                        characterDrop.m_drops.Add(new CharacterDrop.Drop
-                        {
-                            m_prefab = ZNetScene.instance.GetPrefab("LoxPelt"),
-                            m_onePerPlayer = true,
-                            m_amountMin = BasePlugin.ArmorBronzeRequiredConfig.Value,
-                            m_amountMax = BasePlugin.ArmorBronzeRequiredConfig.Value,
-                            m_chance = 1f
-                        });
-                        break;
-                    case UndeadMinion.ArmorType.Bronze:
-                        characterDrop.m_drops.Add(new CharacterDrop.Drop
-                        {
-                            m_prefab = ZNetScene.instance.GetPrefab("Bronze"),
-                            m_onePerPlayer = true,
-                            m_amountMin = BasePlugin.ArmorBronzeRequiredConfig.Value,
-                            m_amountMax = BasePlugin.ArmorBronzeRequiredConfig.Value,
-                            m_chance = 1f
-                        });
-                        break;
-                    case UndeadMinion.ArmorType.Iron:
-                        characterDrop.m_drops.Add(new CharacterDrop.Drop
-                        {
-                            m_prefab = ZNetScene.instance.GetPrefab("Iron"),
-                            m_onePerPlayer = true,
-                            m_amountMin = BasePlugin.ArmorIronRequiredConfig.Value,
-                            m_amountMax = BasePlugin.ArmorIronRequiredConfig.Value,
-                            m_chance = 1f
-                        });
-                        break;
-                    case UndeadMinion.ArmorType.BlackMetal:
-                        characterDrop.m_drops.Add(new CharacterDrop.Drop
-                        {
-                            m_prefab = ZNetScene.instance.GetPrefab("BlackMetal"),
-                            m_onePerPlayer = true,
-                            m_amountMin = BasePlugin.ArmorBlackIronRequiredConfig.Value,
-                            m_amountMax = BasePlugin.ArmorBlackIronRequiredConfig.Value,
-                            m_chance = 1f
-                        });
-                        break;
-                }
-
-                // the component won't be remembered by the game on logout because
-                // only what is on the prefab is remembered. Even changes to the prefab
-                // aren't remembered. So we must write what we're dropping into
-                // the ZDO as well and then read & restore this on Awake
-                minion.RecordDrops(characterDrop);
+                characterDrop = minion.gameObject.AddComponent<CharacterDrop>();
             }
+
+            if (DraugrMinion.DropOnDeath.Value == UndeadMinion.DropType.Everything)
+            {
+                // bones
+                if (DraugrBoneFragmentsRequiredConfig.Value > 0)
+                {
+                    UndeadMinion.AddOrUpdateDrop(characterDrop, "BoneFragments", DraugrBoneFragmentsRequiredConfig.Value);
+                }
+
+                // meat. For now, assume Neck tails
+                if (DraugrMeatRequiredConfig.Value > 0)
+                {
+                    UndeadMinion.AddOrUpdateDrop(characterDrop, "NeckTail", DraugrMeatRequiredConfig.Value);
+                }
+            }
+
+            switch (armorType)
+            {
+                case UndeadMinion.ArmorType.Leather:
+                    UndeadMinion.AddOrUpdateDrop(characterDrop, 
+                        Random.value > .5f ? "DeerHide" : "LeatherScraps", // flip a coin for deer or scraps
+                        BasePlugin.ArmorLeatherScrapsRequiredConfig.Value);
+                    break;
+                case UndeadMinion.ArmorType.LeatherTroll:
+                    UndeadMinion.AddOrUpdateDrop(characterDrop, "TrollHide", BasePlugin.ArmorLeatherScrapsRequiredConfig.Value);
+                    break;
+                case UndeadMinion.ArmorType.LeatherWolf:
+                    UndeadMinion.AddOrUpdateDrop(characterDrop, "WolfPelt", BasePlugin.ArmorLeatherScrapsRequiredConfig.Value);
+                    break;
+                case UndeadMinion.ArmorType.LeatherLox:
+                    UndeadMinion.AddOrUpdateDrop(characterDrop, "LoxPelt", BasePlugin.ArmorLeatherScrapsRequiredConfig.Value);
+                    break;
+                case UndeadMinion.ArmorType.Bronze:
+                    UndeadMinion.AddOrUpdateDrop(characterDrop, "Bronze", BasePlugin.ArmorBronzeRequiredConfig.Value);
+                    break;
+                case UndeadMinion.ArmorType.Iron:
+                    UndeadMinion.AddOrUpdateDrop(characterDrop, "Iron", BasePlugin.ArmorIronRequiredConfig.Value);
+                    break;
+                case UndeadMinion.ArmorType.BlackMetal:
+                    UndeadMinion.AddOrUpdateDrop(characterDrop, "BlackMetal", BasePlugin.ArmorBlackIronRequiredConfig.Value);
+                    break;
+            }
+
+            // the component won't be remembered by the game on logout because
+            // only what is on the prefab is remembered. Even changes to the prefab
+            // aren't remembered. So we must write what we're dropping into
+            // the ZDO as well and then read & restore this on Awake
+            minion.RecordDrops(characterDrop);
         }
     }
 }

--- a/ChebsNecromancy/Minions/SkeletonMinion.cs
+++ b/ChebsNecromancy/Minions/SkeletonMinion.cs
@@ -415,146 +415,72 @@ namespace ChebsNecromancy.Minions
             minion.UndeadMinionMaster = player.GetPlayerName();
 
             // handle refunding of resources on death
-            if (DropOnDeath.Value != DropType.Nothing)
+            if (DropOnDeath.Value == DropType.Nothing) return;
+            
+            // we have to be a little bit cautious. It normally shouldn't exist yet, but maybe some other mod
+            // added it? Who knows
+            var characterDrop = minion.gameObject.GetComponent<CharacterDrop>();
+            if (characterDrop == null)
             {
-                var characterDrop = minion.gameObject.AddComponent<CharacterDrop>();
-
-                if (DropOnDeath.Value == DropType.Everything
-                    && SkeletonWand.BoneFragmentsRequiredConfig.Value > 0)
-                {
-                    // bones
-                    characterDrop.m_drops.Add(new CharacterDrop.Drop
-                    {
-                        m_prefab = ZNetScene.instance.GetPrefab("BoneFragments"),
-                        m_onePerPlayer = true,
-                        m_amountMin = SkeletonWand.BoneFragmentsRequiredConfig.Value,
-                        m_amountMax = SkeletonWand.BoneFragmentsRequiredConfig.Value,
-                        m_chance = 1f
-                    });
-                }
-
-                if (skeletonType == SkeletonType.Miner)
-                {
-                    characterDrop.m_drops.Add(new CharacterDrop.Drop
-                    {
-                        m_prefab = ZNetScene.instance.GetPrefab("HardAntler"),
-                        m_onePerPlayer = true,
-                        m_amountMin = SkeletonWand.MinerSkeletonAntlerRequiredConfig.Value,
-                        m_amountMax = SkeletonWand.MinerSkeletonAntlerRequiredConfig.Value,
-                        m_chance = 1f
-                    });
-                }
-
-                if (skeletonType == SkeletonType.Woodcutter)
-                {
-                    characterDrop.m_drops.Add(new CharacterDrop.Drop
-                    {
-                        m_prefab = ZNetScene.instance.GetPrefab("Flint"),
-                        m_onePerPlayer = true,
-                        m_amountMin = SkeletonWand.WoodcutterSkeletonFlintRequiredConfig.Value,
-                        m_amountMax = SkeletonWand.WoodcutterSkeletonFlintRequiredConfig.Value,
-                        m_chance = 1f
-                    });
-                }
-
-                if (skeletonType is SkeletonType.MageTier1
-                    or SkeletonType.MageTier2
-                    or SkeletonType.MageTier3)
-                {
-                    // surtling core
-                    characterDrop.m_drops.Add(new CharacterDrop.Drop
-                    {
-                        m_prefab = ZNetScene.instance.GetPrefab("SurtlingCore"),
-                        m_onePerPlayer = true,
-                        m_amountMin = BasePlugin.SurtlingCoresRequiredConfig.Value,
-                        m_amountMax = BasePlugin.SurtlingCoresRequiredConfig.Value,
-                        m_chance = 1f
-                    });
-                }
-
-                switch (armorType)
-                {
-                    case ArmorType.Leather:
-                        characterDrop.m_drops.Add(new CharacterDrop.Drop
-                        {
-                            // flip a coin for deer or scraps
-                            m_prefab = Random.value > .5f
-                                ? ZNetScene.instance.GetPrefab("DeerHide")
-                                : ZNetScene.instance.GetPrefab("LeatherScraps"),
-                            m_onePerPlayer = true,
-                            m_amountMin = BasePlugin.ArmorLeatherScrapsRequiredConfig.Value,
-                            m_amountMax = BasePlugin.ArmorLeatherScrapsRequiredConfig.Value,
-                            m_chance = 1f
-                        });
-                        break;
-                    case ArmorType.LeatherTroll:
-                        characterDrop.m_drops.Add(new CharacterDrop.Drop
-                        {
-                            m_prefab = ZNetScene.instance.GetPrefab("TrollHide"),
-                            m_onePerPlayer = true,
-                            m_amountMin = BasePlugin.ArmorBronzeRequiredConfig.Value,
-                            m_amountMax = BasePlugin.ArmorBronzeRequiredConfig.Value,
-                            m_chance = 1f
-                        });
-                        break;
-                    case ArmorType.LeatherWolf:
-                        characterDrop.m_drops.Add(new CharacterDrop.Drop
-                        {
-                            m_prefab = ZNetScene.instance.GetPrefab("WolfPelt"),
-                            m_onePerPlayer = true,
-                            m_amountMin = BasePlugin.ArmorBronzeRequiredConfig.Value,
-                            m_amountMax = BasePlugin.ArmorBronzeRequiredConfig.Value,
-                            m_chance = 1f
-                        });
-                        break;
-                    case ArmorType.LeatherLox:
-                        characterDrop.m_drops.Add(new CharacterDrop.Drop
-                        {
-                            m_prefab = ZNetScene.instance.GetPrefab("LoxPelt"),
-                            m_onePerPlayer = true,
-                            m_amountMin = BasePlugin.ArmorBronzeRequiredConfig.Value,
-                            m_amountMax = BasePlugin.ArmorBronzeRequiredConfig.Value,
-                            m_chance = 1f
-                        });
-                        break;
-                    case ArmorType.Bronze:
-                        characterDrop.m_drops.Add(new CharacterDrop.Drop
-                        {
-                            m_prefab = ZNetScene.instance.GetPrefab("Bronze"),
-                            m_onePerPlayer = true,
-                            m_amountMin = BasePlugin.ArmorBronzeRequiredConfig.Value,
-                            m_amountMax = BasePlugin.ArmorBronzeRequiredConfig.Value,
-                            m_chance = 1f
-                        });
-                        break;
-                    case ArmorType.Iron:
-                        characterDrop.m_drops.Add(new CharacterDrop.Drop
-                        {
-                            m_prefab = ZNetScene.instance.GetPrefab("Iron"),
-                            m_onePerPlayer = true,
-                            m_amountMin = BasePlugin.ArmorIronRequiredConfig.Value,
-                            m_amountMax = BasePlugin.ArmorIronRequiredConfig.Value,
-                            m_chance = 1f
-                        });
-                        break;
-                    case ArmorType.BlackMetal:
-                        characterDrop.m_drops.Add(new CharacterDrop.Drop
-                        {
-                            m_prefab = ZNetScene.instance.GetPrefab("BlackMetal"),
-                            m_onePerPlayer = true,
-                            m_amountMin = BasePlugin.ArmorBlackIronRequiredConfig.Value,
-                            m_amountMax = BasePlugin.ArmorBlackIronRequiredConfig.Value,
-                            m_chance = 1f
-                        });
-                        break;
-                }
-
-                // the component won't be remembered by the game on logout because
-                // only what is on the prefab is remembered. Even changes to the prefab
-                // aren't remembered. So we must write what we're dropping into
-                // the ZDO as well and then read & restore this on Awake
-                minion.RecordDrops(characterDrop);
+                characterDrop = minion.gameObject.AddComponent<CharacterDrop>();
             }
+
+            if (DropOnDeath.Value == DropType.Everything
+                && SkeletonWand.BoneFragmentsRequiredConfig.Value > 0)
+            {
+                // bones
+                AddOrUpdateDrop(characterDrop, "BoneFragments", SkeletonWand.BoneFragmentsRequiredConfig.Value);
+            }
+
+            if (skeletonType == SkeletonType.Miner)
+            {
+                AddOrUpdateDrop(characterDrop, "HardAntler", SkeletonWand.MinerSkeletonAntlerRequiredConfig.Value);
+            }
+
+            if (skeletonType == SkeletonType.Woodcutter)
+            {
+                AddOrUpdateDrop(characterDrop, "Flint", SkeletonWand.WoodcutterSkeletonFlintRequiredConfig.Value);
+            }
+
+            if (skeletonType is SkeletonType.MageTier1
+                or SkeletonType.MageTier2
+                or SkeletonType.MageTier3)
+            {
+                AddOrUpdateDrop(characterDrop, "SurtlingCore", BasePlugin.SurtlingCoresRequiredConfig.Value);
+            }
+
+            switch (armorType)
+            {
+                case ArmorType.Leather:
+                    AddOrUpdateDrop(characterDrop, 
+                        Random.value > .5f ? "DeerHide" : "LeatherScraps", // flip a coin for deer or scraps
+                        BasePlugin.ArmorLeatherScrapsRequiredConfig.Value);
+                    break;
+                case ArmorType.LeatherTroll:
+                    AddOrUpdateDrop(characterDrop, "TrollHide", BasePlugin.ArmorLeatherScrapsRequiredConfig.Value);
+                    break;
+                case ArmorType.LeatherWolf:
+                    AddOrUpdateDrop(characterDrop, "WolfPelt", BasePlugin.ArmorLeatherScrapsRequiredConfig.Value);
+                    break;
+                case ArmorType.LeatherLox:
+                    AddOrUpdateDrop(characterDrop, "LoxPelt", BasePlugin.ArmorLeatherScrapsRequiredConfig.Value);
+                    break;
+                case ArmorType.Bronze:
+                    AddOrUpdateDrop(characterDrop, "Bronze", BasePlugin.ArmorBronzeRequiredConfig.Value);
+                    break;
+                case ArmorType.Iron:
+                    AddOrUpdateDrop(characterDrop, "Iron", BasePlugin.ArmorIronRequiredConfig.Value);
+                    break;
+                case ArmorType.BlackMetal:
+                    AddOrUpdateDrop(characterDrop, "BlackMetal", BasePlugin.ArmorBlackIronRequiredConfig.Value);
+                    break;
+            }
+
+            // the component won't be remembered by the game on logout because
+            // only what is on the prefab is remembered. Even changes to the prefab
+            // aren't remembered. So we must write what we're dropping into
+            // the ZDO as well and then read & restore this on Awake
+            minion.RecordDrops(characterDrop);
         }
         
         public static void ConsumeResources(SkeletonType skeletonType, ArmorType armorType)

--- a/ChebsNecromancy/Package/README.md
+++ b/ChebsNecromancy/Package/README.md
@@ -80,6 +80,7 @@ Detailed info in the [wiki](https://github.com/jpw1991/chebs-necromancy/wiki). H
 	+ [**Spirit Pylon**](https://github.com/jpw1991/chebs-necromancy/wiki/piece_spiritpylon): Spawns spirits to defend your base.
 	+ [**Farming Pylon**](https://github.com/jpw1991/chebs-necromancy/wiki/FarmingPylon): Automatically harvests your crops. Combine with **Seed Totem** ([Nexus](https://www.nexusmods.com/valheim/mods/876), [Thunderstore](https://valheim.thunderstore.io/package/MathiasDecrock/SeedTotem/)) to then automatically replant those seeds for an automated base.
 	+ [**Repair Pylon**](https://github.com/jpw1991/chebs-necromancy/wiki/RepairPylon): Consumes resin to repair your structures.
+	+ [**Treasure Pylon**](https://github.com/jpw1991/chebs-necromancy/wiki/TreasurePylon): Organizes your chests in a rather chaotic way. By default only works on the basic wooden boxes but can be told to sort other things too via config. The idea is that Neckros haul all this stuff back, then the Treasure Pylon organizes it.
 
 ### Config
 
@@ -128,6 +129,7 @@ You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
 Date | Version | Notes
 --- | --- | ---
+27/03/2023 | 2.5.9 | fix a null object exception for structure friendly-fire code; ships ignore minion impact damage
 25/03/2023 | 2.5.8 | miners pop an entire rock/node in one whack because completely mining the fragments seems impossible
 25/03/2023 | 2.5.7 | permit multiple miners to whack same rock; overhaul rock whacking logic for lumberjacks and miners; remove collision on draugr heads
 23/03/2023 | 2.5.6 | make miners lerp as they mine so that they have increased odds of being able to connect a blow with a stone; fix null object

--- a/ChebsNecromancy/Package/README.md
+++ b/ChebsNecromancy/Package/README.md
@@ -129,7 +129,7 @@ You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
 Date | Version | Notes
 --- | --- | ---
-27/03/2023 | 2.5.9 | fix a null object exception for structure friendly-fire code; ships ignore minion impact damage
+27/03/2023 | 2.5.9 | fix a null object exception for structure friendly-fire code; ships ignore minion impact damage; fix problem of duplicate resource drops on death if crate is enabled
 25/03/2023 | 2.5.8 | miners pop an entire rock/node in one whack because completely mining the fragments seems impossible
 25/03/2023 | 2.5.7 | permit multiple miners to whack same rock; overhaul rock whacking logic for lumberjacks and miners; remove collision on draugr heads
 23/03/2023 | 2.5.6 | make miners lerp as they mine so that they have increased odds of being able to connect a blow with a stone; fix null object

--- a/ChebsNecromancy/Package/manifest.json
+++ b/ChebsNecromancy/Package/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "name": "ChebsNecromancy",
   "description": "Cheb's Necromancy adds Necromancy to Valheim via craftable wands and structures. Minions will follow you, guard your base, and perform menial tasks.",
-  "version_number": "2.5.8",
+  "version_number": "2.5.9",
   "website_url": "https://github.com/jpw1991/chebs-necromancy",
   "dependencies": [
     "ValheimModding-Jotunn-2.11.0"

--- a/ChebsNecromancy/Patches/CharacterDropPatches.cs
+++ b/ChebsNecromancy/Patches/CharacterDropPatches.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using ChebsNecromancy.Minions;
 using HarmonyLib;
+using UnityEngine;
 
 // ReSharper disable InconsistentNaming
 // ReSharper disable UnusedParameter.Local
@@ -39,15 +40,18 @@ namespace ChebsNecromancy.Patches
                 };
                 ___m_drops.Add(bones);
             }
-        }
-    }
-    
-    [HarmonyPatch(typeof(CharacterDrop), "OnDeath")]
-    class OnDeathDropPatch
-    {
-        [HarmonyPrefix]
-        static void Prefix(CharacterDrop __instance)
-        {
+
+            // if (__instance.TryGetComponent(out UndeadMinion undeadMinion))
+            //     //&& undeadMinion.ItemsDropped)
+            // {
+            //     Jotunn.Logger.LogInfo($"name={__instance.name}");
+            //     if (undeadMinion.ItemsDropped)
+            //     {
+            //         Jotunn.Logger.LogInfo($"Removing all drops from {__instance.name}");
+            //         ___m_drops.RemoveAll(a => true);                    
+            //     }
+            // }
+            
             // Although Container component is on the Neckro, its OnDestroyed
             // isn't called on the death of the creature. So instead, implement
             // its same functionality in the creature's OnDeath instead.
@@ -69,14 +73,78 @@ namespace ChebsNecromancy.Patches
                     && SkeletonMinion.PackDropItemsIntoCargoCrate.Value)
                 {
                     undeadMinion.DepositIntoNearbyDeathCrate(__instance);
+                    // var depositedSuccessfully = undeadMinion.DepositIntoNearbyDeathCrate(__instance);
+                    // undeadMinion.ItemsDropped = depositedSuccessfully;
+                    //__instance.m_dropsEnabled = !depositedSuccessfully;
+                    //__instance.m_drops.RemoveAll(a => depositedSuccessfully);
+                    //Jotunn.Logger.LogInfo($"depositedSuccessfully={depositedSuccessfully}, m_dropsEnabled={__instance.m_dropsEnabled}");
                 }
                 else if (undeadMinion is DraugrMinion
                     && DraugrMinion.DropOnDeath.Value != UndeadMinion.DropType.Nothing
                     && DraugrMinion.PackDropItemsIntoCargoCrate.Value)
                 {
                     undeadMinion.DepositIntoNearbyDeathCrate(__instance);
+                    // var depositedSuccessfully = undeadMinion.DepositIntoNearbyDeathCrate(__instance);
+                    // undeadMinion.ItemsDropped = depositedSuccessfully;
+                    //__instance.m_dropsEnabled = !depositedSuccessfully;
+                    //__instance.m_drops.RemoveAll(a => depositedSuccessfully);
+                    //Jotunn.Logger.LogInfo($"depositedSuccessfully={depositedSuccessfully}, m_dropsEnabled={__instance.m_dropsEnabled}");
+                }
+
+                if (undeadMinion.ItemsDropped)
+                {
+                    Jotunn.Logger.LogInfo("items dropped is true");
+                    ___m_drops.RemoveAll(a => true);
                 }
             }
         }
     }
+    
+    // [HarmonyPatch(typeof(CharacterDrop), "OnDeath")]
+    // class OnDeathDropPatch
+    // {
+    //     [HarmonyPrefix]
+    //     static void Prefix(CharacterDrop __instance)
+    //     {
+    //         // Although Container component is on the Neckro, its OnDestroyed
+    //         // isn't called on the death of the creature. So instead, implement
+    //         // its same functionality in the creature's OnDeath instead.
+    //         if (__instance.TryGetComponent(out NeckroGathererMinion _))
+    //         {
+    //             if (__instance.TryGetComponent(out Container container))
+    //             {
+    //                 container.DropAllItems(container.m_destroyedLootPrefab);
+    //             }
+    //         }
+    //
+    //         // For all other minions, check if they're supposed to be dropping
+    //         // items and whether these should be packed into a crate or not.
+    //         // We don't want ppls surtling cores and things to be claimed by davey jones
+    //         else if (__instance.TryGetComponent(out UndeadMinion undeadMinion))
+    //         {
+    //             if (undeadMinion is SkeletonMinion
+    //                 && SkeletonMinion.DropOnDeath.Value != UndeadMinion.DropType.Nothing
+    //                 && SkeletonMinion.PackDropItemsIntoCargoCrate.Value)
+    //             {
+    //                 undeadMinion.DepositIntoNearbyDeathCrate(__instance);
+    //                 // var depositedSuccessfully = undeadMinion.DepositIntoNearbyDeathCrate(__instance);
+    //                 // undeadMinion.ItemsDropped = depositedSuccessfully;
+    //                 //__instance.m_dropsEnabled = !depositedSuccessfully;
+    //                 //__instance.m_drops.RemoveAll(a => depositedSuccessfully);
+    //                 //Jotunn.Logger.LogInfo($"depositedSuccessfully={depositedSuccessfully}, m_dropsEnabled={__instance.m_dropsEnabled}");
+    //             }
+    //             else if (undeadMinion is DraugrMinion
+    //                 && DraugrMinion.DropOnDeath.Value != UndeadMinion.DropType.Nothing
+    //                 && DraugrMinion.PackDropItemsIntoCargoCrate.Value)
+    //             {
+    //                 undeadMinion.DepositIntoNearbyDeathCrate(__instance);
+    //                 // var depositedSuccessfully = undeadMinion.DepositIntoNearbyDeathCrate(__instance);
+    //                 // undeadMinion.ItemsDropped = depositedSuccessfully;
+    //                 //__instance.m_dropsEnabled = !depositedSuccessfully;
+    //                 //__instance.m_drops.RemoveAll(a => depositedSuccessfully);
+    //                 //Jotunn.Logger.LogInfo($"depositedSuccessfully={depositedSuccessfully}, m_dropsEnabled={__instance.m_dropsEnabled}");
+    //             }
+    //         }
+    //     }
+    // }
 }

--- a/ChebsNecromancy/Patches/ImpactEffectPatches.cs
+++ b/ChebsNecromancy/Patches/ImpactEffectPatches.cs
@@ -1,0 +1,34 @@
+using ChebsNecromancy.Minions;
+using HarmonyLib;
+using UnityEngine;
+
+// ReSharper disable InconsistentNaming
+// ReSharper disable UnusedParameter.Local
+
+// Harmony patching is very sensitive regarding parameter names. Everything in this region should be hand crafted
+// and not touched by well-meaning but clueless IDE optimizations.
+// eg.
+// * __instance MUST be named with exactly two underscores.
+// * ___m_drops MUST be named with exactly three underscores.
+// * Unused parameters must be left there because they must match the method to override
+// * All patch methods need to be static
+//
+// This is because all of this has a special meaning to Harmony.
+
+namespace ChebsNecromancy.Patches
+{
+    [HarmonyPatch(typeof(ImpactEffect), "OnCollisionEnter")]
+    class ImpactEffectPatch
+    {
+        // stop minions from damaging ships
+        static bool Prefix(ref Collision info, ImpactEffect __instance)
+        {
+            if (info.gameObject.TryGetComponent(out UndeadMinion _))
+            {
+                return false; // deny base method completion
+            }
+
+            return true;
+        }
+    }
+}

--- a/ChebsNecromancy/Patches/WearNTearPatches.cs
+++ b/ChebsNecromancy/Patches/WearNTearPatches.cs
@@ -27,7 +27,7 @@ namespace ChebsNecromancy.Patches
             if (attacker != null 
                 && attacker.TryGetComponent(out UndeadMinion _))
             {
-                if (___m_piece.IsPlacedByPlayer())
+                if (___m_piece != null && ___m_piece.IsPlacedByPlayer())
                 {
                     hit.m_damage.m_damage = 0f;
                     hit.m_damage.m_blunt = 0f;

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
 Date | Version | Notes
 --- | --- | ---
-27/03/2023 | 2.5.9 | fix a null object exception for structure friendly-fire code; ships ignore minion impact damage
+27/03/2023 | 2.5.9 | fix a null object exception for structure friendly-fire code; ships ignore minion impact damage; fix problem of duplicate resource drops on death if crate is enabled
 25/03/2023 | 2.5.8 | miners pop an entire rock/node in one whack because completely mining the fragments seems impossible
 25/03/2023 | 2.5.7 | permit multiple miners to whack same rock; overhaul rock whacking logic for lumberjacks and miners; remove collision on draugr heads
 23/03/2023 | 2.5.6 | make miners lerp as they mine so that they have increased odds of being able to connect a blow with a stone; fix null object

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
 Date | Version | Notes
 --- | --- | ---
+27/03/2023 | 2.5.9 | fix a null object exception for structure friendly-fire code; ships ignore minion impact damage
 25/03/2023 | 2.5.8 | miners pop an entire rock/node in one whack because completely mining the fragments seems impossible
 25/03/2023 | 2.5.7 | permit multiple miners to whack same rock; overhaul rock whacking logic for lumberjacks and miners; remove collision on draugr heads
 23/03/2023 | 2.5.6 | make miners lerp as they mine so that they have increased odds of being able to connect a blow with a stone; fix null object


### PR DESCRIPTION
# Description

- fix a null object exception for structure friendly-fire code
- ships ignore minion impact damage
- fix duplicate resources on death

Compiled pre-release version [here](https://github.com/jpw1991/chebs-necromancy/releases/tag/2.5.9).

# Testing

- [ ] Structure friendly-fire code
  - Make some mages
  - Go to fuling village
  - Let mages impact the fuling structures via their AoE spells
  - The fuling structures should blow up and be destroyed
  - No errors should appear in code
- [ ] Ships ignore minion impact damage
  - Make a ship eg. Karve
  - Teleport heaps of minions onto it and/or create more
  - As you sail around, the minions shouldn't cause any damage to the ship
- [ ] No duplicate resources on death
  - In the previous versions it could happen that with `Everything` or `JustResources`, the crate would spawn with items and then the corpse would also drop those same items again. That should be fixed now
  - To test, make minions and kill them. They should only drop what went into making them ONCE (not twice)
  - **Known problem:** This doesn't fix the behavior of `Everything` and `JustResources` dropping more than they should. I'm trying to fix that as well but it's not ready yet
