### PR TITLE
2.5.10: improve repair pylon behaviour; upgrade to jotunn 1.11.2

### DIFF
--- a/ChebsNecromancy/BasePlugin.cs
+++ b/ChebsNecromancy/BasePlugin.cs
@@ -34,7 +34,7 @@ namespace ChebsNecromancy
     {
         public const string PluginGuid = "com.chebgonaz.ChebsNecromancy";
         public const string PluginName = "ChebsNecromancy";
-        public const string PluginVersion = "2.5.10";
+        public const string PluginVersion = "2.5.11";
         private const string ConfigFileName =  PluginGuid + ".cfg";
         private static readonly string ConfigFileFullPath = Path.Combine(Paths.ConfigPath, ConfigFileName);
 

--- a/ChebsNecromancy/BasePlugin.cs
+++ b/ChebsNecromancy/BasePlugin.cs
@@ -34,7 +34,7 @@ namespace ChebsNecromancy
     {
         public const string PluginGuid = "com.chebgonaz.ChebsNecromancy";
         public const string PluginName = "ChebsNecromancy";
-        public const string PluginVersion = "2.5.9";
+        public const string PluginVersion = "2.5.10";
         private const string ConfigFileName =  PluginGuid + ".cfg";
         private static readonly string ConfigFileFullPath = Path.Combine(Paths.ConfigPath, ConfigFileName);
 

--- a/ChebsNecromancy/ChebsNecromancy.csproj
+++ b/ChebsNecromancy/ChebsNecromancy.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\JotunnLib.2.11.0\build\JotunnLib.props" Condition="Exists('..\packages\JotunnLib.2.11.0\build\JotunnLib.props')" />
+  <Import Project="..\packages\JotunnLib.2.11.2\build\JotunnLib.props" Condition="Exists('..\packages\JotunnLib.2.11.2\build\JotunnLib.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -58,8 +58,8 @@
     <Reference Include="assembly_valheim_">
       <HintPath>libs\assembly_valheim_publicized.dll</HintPath>
     </Reference>
-    <Reference Include="Jotunn, Version=2.11.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\JotunnLib.2.11.0\lib\net462\Jotunn.dll</HintPath>
+    <Reference Include="Jotunn, Version=2.11.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\JotunnLib.2.11.2\lib\net462\Jotunn.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
       <HintPath>..\packages\Mono.Cecil.0.11.4\lib\net40\Mono.Cecil.dll</HintPath>
@@ -257,6 +257,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\JotunnLib.2.11.0\build\JotunnLib.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JotunnLib.2.11.0\build\JotunnLib.props'))" />
+    <Error Condition="!Exists('..\packages\JotunnLib.2.11.2\build\JotunnLib.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JotunnLib.2.11.2\build\JotunnLib.props'))" />
   </Target>
 </Project>

--- a/ChebsNecromancy/CustomPrefabs/OrbOfBeckoningProjectile.cs
+++ b/ChebsNecromancy/CustomPrefabs/OrbOfBeckoningProjectile.cs
@@ -17,10 +17,11 @@ namespace ChebsNecromancy.CustomPrefabs
             if (!TryGetComponent(out Projectile projectile)
                 || !projectile.m_owner.TryGetComponent(out player))
             {
-                Logger.LogError($"{name}'s projectile.owner has no player component! NPC using this weapon?");
+                // In this case, the item is likely being wielded by an NPC. So return prematurely and don't worry
+                // about the code.
                 return;
             }
-            
+
             // make all minions that belong to the player follow the ball
             List<Character> allCharacters = new();
             Character.GetCharactersInRange(player.transform.position, SkeletonWand.SkeletonSetFollowRange.Value, allCharacters);

--- a/ChebsNecromancy/Minions/NeckroGathererMinion.cs
+++ b/ChebsNecromancy/Minions/NeckroGathererMinion.cs
@@ -113,6 +113,20 @@ namespace ChebsNecromancy.Minions
         {
             if (ZNet.instance == null
                 || !(Time.time > lastUpdate)) return;
+            
+            // Some users get null object exceptions inside the neckro's Update method. IDK why exactly that would be.
+            // Mod conflicts? Don't know. So to mitigate this, just be extra careful about nulls and abort if anything
+            // is null.
+            if (container == null && !TryGetComponent(out container))
+            {
+                Logger.LogError("Neckro container is null and cannot be retrieved!");
+                return;
+            }
+            if (_monsterAI == null && !TryGetComponent(out _monsterAI))
+            {
+                Logger.LogError("Neckro MonsterAI is null and cannot be retrieved!");
+                return;
+            }
 
             bool canPick = LookForNearbyItems();
             if (canPick)
@@ -140,7 +154,7 @@ namespace ChebsNecromancy.Minions
                             {
                                 DepositItems();
                             }
-                        }                        
+                        }              
                     }
                     else
                     {

--- a/ChebsNecromancy/Package/README.md
+++ b/ChebsNecromancy/Package/README.md
@@ -129,6 +129,7 @@ You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
 Date | Version | Notes
 --- | --- | ---
+28/03/2023 | 2.5.10 | improve repair pylon behaviour; upgrade to jotunn 1.11.2
 27/03/2023 | 2.5.9 | fix a null object exception for structure friendly-fire code; ships ignore minion impact damage; fix problem of duplicate resource drops on death if crate is enabled
 25/03/2023 | 2.5.8 | miners pop an entire rock/node in one whack because completely mining the fragments seems impossible
 25/03/2023 | 2.5.7 | permit multiple miners to whack same rock; overhaul rock whacking logic for lumberjacks and miners; remove collision on draugr heads

--- a/ChebsNecromancy/Package/README.md
+++ b/ChebsNecromancy/Package/README.md
@@ -129,6 +129,7 @@ You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
 Date | Version | Notes
 --- | --- | ---
+28/03/2023 | 2.5.11 | don't log error if NPC is using the Orb of Beckoning
 28/03/2023 | 2.5.10 | improve repair pylon behaviour; upgrade to jotunn 1.11.2; make neckro update more null resistant
 27/03/2023 | 2.5.9 | fix a null object exception for structure friendly-fire code; ships ignore minion impact damage; fix problem of duplicate resource drops on death if crate is enabled
 25/03/2023 | 2.5.8 | miners pop an entire rock/node in one whack because completely mining the fragments seems impossible

--- a/ChebsNecromancy/Package/README.md
+++ b/ChebsNecromancy/Package/README.md
@@ -129,7 +129,7 @@ You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
 Date | Version | Notes
 --- | --- | ---
-28/03/2023 | 2.5.10 | improve repair pylon behaviour; upgrade to jotunn 1.11.2
+28/03/2023 | 2.5.10 | improve repair pylon behaviour; upgrade to jotunn 1.11.2; make neckro update more null resistant
 27/03/2023 | 2.5.9 | fix a null object exception for structure friendly-fire code; ships ignore minion impact damage; fix problem of duplicate resource drops on death if crate is enabled
 25/03/2023 | 2.5.8 | miners pop an entire rock/node in one whack because completely mining the fragments seems impossible
 25/03/2023 | 2.5.7 | permit multiple miners to whack same rock; overhaul rock whacking logic for lumberjacks and miners; remove collision on draugr heads

--- a/ChebsNecromancy/Package/manifest.json
+++ b/ChebsNecromancy/Package/manifest.json
@@ -1,9 +1,9 @@
 ﻿{
   "name": "ChebsNecromancy",
   "description": "Cheb's Necromancy adds Necromancy to Valheim via craftable wands and structures. Minions will follow you, guard your base, and perform menial tasks.",
-  "version_number": "2.5.9",
+  "version_number": "2.5.10",
   "website_url": "https://github.com/jpw1991/chebs-necromancy",
   "dependencies": [
-    "ValheimModding-Jotunn-2.11.0"
+    "ValheimModding-Jotunn-2.11.2"
   ]
 }

--- a/ChebsNecromancy/Package/manifest.json
+++ b/ChebsNecromancy/Package/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "name": "ChebsNecromancy",
   "description": "Cheb's Necromancy adds Necromancy to Valheim via craftable wands and structures. Minions will follow you, guard your base, and perform menial tasks.",
-  "version_number": "2.5.10",
+  "version_number": "2.5.11",
   "website_url": "https://github.com/jpw1991/chebs-necromancy",
   "dependencies": [
     "ValheimModding-Jotunn-2.11.2"

--- a/ChebsNecromancy/packages.config
+++ b/ChebsNecromancy/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="HarmonyX" version="2.10.1" targetFramework="net48" />
-  <package id="JotunnLib" version="2.11.0" targetFramework="net48" />
+  <package id="JotunnLib" version="2.11.2" targetFramework="net48" />
   <package id="Mono.Cecil" version="0.11.4" targetFramework="net462" />
   <package id="MonoMod" version="22.7.31.1" targetFramework="net48" />
   <package id="MonoMod.RuntimeDetour" version="22.7.31.1" targetFramework="net48" />

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
 Date | Version | Notes
 --- | --- | ---
+28/03/2023 | 2.5.10 | improve repair pylon behaviour; upgrade to jotunn 1.11.2
 27/03/2023 | 2.5.9 | fix a null object exception for structure friendly-fire code; ships ignore minion impact damage; fix problem of duplicate resource drops on death if crate is enabled
 25/03/2023 | 2.5.8 | miners pop an entire rock/node in one whack because completely mining the fragments seems impossible
 25/03/2023 | 2.5.7 | permit multiple miners to whack same rock; overhaul rock whacking logic for lumberjacks and miners; remove collision on draugr heads

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
 Date | Version | Notes
 --- | --- | ---
+28/03/2023 | 2.5.11 | don't log error if NPC is using the Orb of Beckoning
 28/03/2023 | 2.5.10 | improve repair pylon behaviour; upgrade to jotunn 1.11.2; make neckro update more null resistant
 27/03/2023 | 2.5.9 | fix a null object exception for structure friendly-fire code; ships ignore minion impact damage; fix problem of duplicate resource drops on death if crate is enabled
 25/03/2023 | 2.5.8 | miners pop an entire rock/node in one whack because completely mining the fragments seems impossible

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
 Date | Version | Notes
 --- | --- | ---
-28/03/2023 | 2.5.10 | improve repair pylon behaviour; upgrade to jotunn 1.11.2
+28/03/2023 | 2.5.10 | improve repair pylon behaviour; upgrade to jotunn 1.11.2; make neckro update more null resistant
 27/03/2023 | 2.5.9 | fix a null object exception for structure friendly-fire code; ships ignore minion impact damage; fix problem of duplicate resource drops on death if crate is enabled
 25/03/2023 | 2.5.8 | miners pop an entire rock/node in one whack because completely mining the fragments seems impossible
 25/03/2023 | 2.5.7 | permit multiple miners to whack same rock; overhaul rock whacking logic for lumberjacks and miners; remove collision on draugr heads


### PR DESCRIPTION
# Testing

- [ ] Improve repair pylon behaviour
  - Keeping the thresholds in mind, check that every damaged structure is being properly repaired
  - By default, wood is not repaired until <= 25% hp, whereas other objects eg. stone are always repaired
- [ ] `AlwaysRepair` config entry
  - Using this new comma delimited list of prefab names, certain prefabs will always be repaired and ignore the aforementioned thresholds. Default value are sharpened stakes because although wooden, they should always be kept at 100% hp.
- [ ] If an NPC uses the `Orb of Beckoning`, there should be no error reported