### PR TITLE
2.5.12: configurable teleport cooldown & durability cost

### DIFF
--- a/ChebsNecromancy/BasePlugin.cs
+++ b/ChebsNecromancy/BasePlugin.cs
@@ -34,7 +34,7 @@ namespace ChebsNecromancy
     {
         public const string PluginGuid = "com.chebgonaz.ChebsNecromancy";
         public const string PluginName = "ChebsNecromancy";
-        public const string PluginVersion = "2.5.12";
+        public const string PluginVersion = "2.5.13";
         private const string ConfigFileName =  PluginGuid + ".cfg";
         private static readonly string ConfigFileFullPath = Path.Combine(Paths.ConfigPath, ConfigFileName);
 

--- a/ChebsNecromancy/BasePlugin.cs
+++ b/ChebsNecromancy/BasePlugin.cs
@@ -34,7 +34,7 @@ namespace ChebsNecromancy
     {
         public const string PluginGuid = "com.chebgonaz.ChebsNecromancy";
         public const string PluginName = "ChebsNecromancy";
-        public const string PluginVersion = "2.5.11";
+        public const string PluginVersion = "2.5.12";
         private const string ConfigFileName =  PluginGuid + ".cfg";
         private static readonly string ConfigFileFullPath = Path.Combine(Paths.ConfigPath, ConfigFileName);
 

--- a/ChebsNecromancy/Items/Armor/Player/SpectralShroud.cs
+++ b/ChebsNecromancy/Items/Armor/Player/SpectralShroud.cs
@@ -165,7 +165,10 @@ namespace ChebsNecromancy.Items
                 30f,
                 charactersInRange
                 );
-            foreach (var character in charactersInRange.Where(character => character != null && character.m_faction != Character.Faction.Players))
+            foreach (var character in charactersInRange.Where(
+                         character => 
+                             character != null
+                             && (character.m_faction != Character.Faction.Players && !character.m_tamed)))
             {
                 enemy = character;
                 return true;

--- a/ChebsNecromancy/Items/Wands/SkeletonWand.cs
+++ b/ChebsNecromancy/Items/Wands/SkeletonWand.cs
@@ -217,6 +217,13 @@ namespace ChebsNecromancy.Items
                 UnlockExtraResourceConsumptionButton == null
                 || ZInput.GetButton(UnlockExtraResourceConsumptionButton.Name);
 
+            // handle visual side of keyhints
+            // if (TeleportButton != null && TeleportCooldown.Value > 0)
+            // {
+            //     TeleportButton.HintToken = Time.time - lastTeleport < TeleportCooldown.Value ? "Cooldown" : "$friendlyskeletonwand_teleport";
+            // }
+
+            // handle input responses
             if (CreateMinionButton != null && ZInput.GetButton(CreateMinionButton.Name))
             {
                 SpawnSkeleton();

--- a/ChebsNecromancy/Package/manifest.json
+++ b/ChebsNecromancy/Package/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "name": "ChebsNecromancy",
   "description": "Cheb's Necromancy adds Necromancy to Valheim via craftable wands and structures. Minions will follow you, guard your base, and perform menial tasks.",
-  "version_number": "2.5.12",
+  "version_number": "2.5.13",
   "website_url": "https://github.com/jpw1991/chebs-necromancy",
   "dependencies": [
     "ValheimModding-Jotunn-2.11.2"

--- a/ChebsNecromancy/Package/manifest.json
+++ b/ChebsNecromancy/Package/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "name": "ChebsNecromancy",
   "description": "Cheb's Necromancy adds Necromancy to Valheim via craftable wands and structures. Minions will follow you, guard your base, and perform menial tasks.",
-  "version_number": "2.5.11",
+  "version_number": "2.5.12",
   "website_url": "https://github.com/jpw1991/chebs-necromancy",
   "dependencies": [
     "ValheimModding-Jotunn-2.11.2"

--- a/ChebsNecromancy/Structures/BatBeacon.cs
+++ b/ChebsNecromancy/Structures/BatBeacon.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using BepInEx.Configuration;
 using ChebsNecromancy.Common;
@@ -92,7 +91,7 @@ namespace ChebsNecromancy.Structures
                     }
                 }
 
-                if (!EnemiesNearby(out Character characterInRange)) continue;
+                if (!EnemiesNearby(out Character characterInRange, SightRadius.Value)) continue;
                 
                 // spawn up until the limit
                 if (SpawnedBats.Count < MaxBats.Value)
@@ -107,23 +106,6 @@ namespace ChebsNecromancy.Structures
                     }
                 }
             }
-        }
-
-        protected bool EnemiesNearby(out Character characterInRange)
-        {
-            List<Character> charactersInRange = new();
-            Character.GetCharactersInRange(
-                transform.position,
-                SightRadius.Value,
-                charactersInRange
-                );
-            foreach (var character in charactersInRange.Where(character => character != null && character.m_faction != Character.Faction.Players))
-            {
-                characterInRange = character;
-                return true;
-            }
-            characterInRange = null;
-            return false;
         }
 
         protected GameObject SpawnFriendlyBat()

--- a/ChebsNecromancy/Structures/SpiritPylon.cs
+++ b/ChebsNecromancy/Structures/SpiritPylon.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using BepInEx.Configuration;
 using ChebsNecromancy.Common;
@@ -97,7 +96,7 @@ namespace ChebsNecromancy.Structures
                 }
 
                 if (Player.m_localPlayer == null) continue;
-                if (!EnemiesNearby(out Character characterInRange)) continue;
+                if (!EnemiesNearby(out Character characterInRange, SightRadius.Value)) continue;
                 
                 // spawn ghosts up until the limit
                 if (SpawnedGhosts.Count < MaxGhosts.Value)
@@ -112,23 +111,6 @@ namespace ChebsNecromancy.Structures
                     }
                 }
             }
-        }
-
-        protected bool EnemiesNearby(out Character characterInRange)
-        {
-            List<Character> charactersInRange = new();
-            Character.GetCharactersInRange(
-                transform.position,
-                SightRadius.Value,
-                charactersInRange
-                );
-            foreach (var character in charactersInRange.Where(character => character != null && character.m_faction != Character.Faction.Players))
-            {
-                characterInRange = character;
-                return true;
-            }
-            characterInRange = null;
-            return false;
         }
 
         protected GameObject SpawnFriendlyGhost()

--- a/ChebsNecromancy/Structures/Structure.cs
+++ b/ChebsNecromancy/Structures/Structure.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using ChebsNecromancy.Common;
 using UnityEngine;
 
@@ -10,6 +12,26 @@ namespace ChebsNecromancy.Structures
         public static void UpdateRecipe()
         {
             
+        }
+        
+        protected bool EnemiesNearby(out Character characterInRange, float radius)
+        {
+            List<Character> charactersInRange = new();
+            Character.GetCharactersInRange(
+                transform.position,
+                radius,
+                charactersInRange
+            );
+            foreach (var character in charactersInRange.Where(
+                         character => 
+                             character != null
+                             && (character.m_faction != Character.Faction.Players && !character.m_tamed)))
+            {
+                characterInRange = character;
+                return true;
+            }
+            characterInRange = null;
+            return false;
         }
     }
 }

--- a/ChebsNecromancy/Structures/TreasurePylon.cs
+++ b/ChebsNecromancy/Structures/TreasurePylon.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Linq;
 using System.Reflection;
@@ -6,7 +5,6 @@ using BepInEx.Configuration;
 using ChebsNecromancy.Common;
 using ChebsNecromancy.Minions;
 using UnityEngine;
-using Random = UnityEngine.Random;
 
 namespace ChebsNecromancy.Structures
 {


### PR DESCRIPTION
# Description

- 2.5.13: Character.m_tamed is also checked when looking for hostiles so that things like tamed animals aren't detected
- 2.5.12: configurable teleport cooldown & durability cost

## Testing - Compiled pre-release 2.5.13 [here](https://github.com/jpw1991/chebs-necromancy/releases/tag/2.5.13)

- **Hostile detection**
 - Enemies should still trigger a wraith/spirit/bat spawn
 - A tamed creature should not
 - Testing via console:
   - `spawn boar 5` to spawn 5 boars
   - Ghosts should spawn in reaction to hostile presence
   - `tame` to tame the pigs
   - [ ] Ghosts should not be hostile to the pigs anymore
   - [ ] Ghosts should no longer be spawning
 - [ ] Spirit Pylon works
 - [ ] Sprectral Shroud works
 - [ ] Bat Pylon works
- **Configurable teleport**
  - [ ] Try setting a durability damage for teleport
  - [ ] Check if the cooldown is working (by default, 5 seconds)
