### PR TITLE
178 skeleton wand eats bone fragments if theres not enough to summon a minion

### DIFF
--- a/ChebsNecromancy/BasePlugin.cs
+++ b/ChebsNecromancy/BasePlugin.cs
@@ -34,7 +34,7 @@ namespace ChebsNecromancy
     {
         public const string PluginGuid = "com.chebgonaz.ChebsNecromancy";
         public const string PluginName = "ChebsNecromancy";
-        public const string PluginVersion = "2.5.13";
+        public const string PluginVersion = "2.5.14";
         private const string ConfigFileName =  PluginGuid + ".cfg";
         private static readonly string ConfigFileFullPath = Path.Combine(Paths.ConfigPath, ConfigFileName);
 

--- a/ChebsNecromancy/BasePlugin.cs
+++ b/ChebsNecromancy/BasePlugin.cs
@@ -34,7 +34,7 @@ namespace ChebsNecromancy
     {
         public const string PluginGuid = "com.chebgonaz.ChebsNecromancy";
         public const string PluginName = "ChebsNecromancy";
-        public const string PluginVersion = "2.5.14";
+        public const string PluginVersion = "2.5.15";
         private const string ConfigFileName =  PluginGuid + ".cfg";
         private static readonly string ConfigFileFullPath = Path.Combine(Paths.ConfigPath, ConfigFileName);
 

--- a/ChebsNecromancy/Items/Armor/Player/NecromancerCape.cs
+++ b/ChebsNecromancy/Items/Armor/Player/NecromancerCape.cs
@@ -42,7 +42,7 @@ namespace ChebsNecromancy.Items
 
         public void CreateConfigs(BaseUnityPlugin plugin)
         {
-            EmblemConfig = plugin.Config.Bind("NecromancerCape (Client)", "Emblem", Emblem.Blank, 
+            EmblemConfig = plugin.Config.Bind($"{GetType().Name} (Client)", "Emblem", Emblem.Blank, 
                 new ConfigDescription("The symbol on the cape of your armored minions."));
         }
 

--- a/ChebsNecromancy/Items/Armor/Player/NecromancerHood.cs
+++ b/ChebsNecromancy/Items/Armor/Player/NecromancerHood.cs
@@ -24,23 +24,23 @@ namespace ChebsNecromancy.Items
         {
             base.CreateConfigs(plugin);
 
-            Allowed = plugin.Config.Bind("NecromancerHood (Server Synced)", "NecromancerHoodAllowed",
+            Allowed = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "NecromancerHoodAllowed",
                 true, new ConfigDescription("Whether crafting a Necromancer's Hood is allowed or not.", null,
                 new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            CraftingStationRequired = plugin.Config.Bind("NecromancerHood (Server Synced)", "NecromancerHoodCraftingStation",
+            CraftingStationRequired = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "NecromancerHoodCraftingStation",
                 CraftingTable.Workbench, new ConfigDescription("Crafting station where Necromancer Hood is available", null,
                 new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            CraftingStationLevel = plugin.Config.Bind("NecromancerHood (Server Synced)", "NecromancerHoodCraftingStationLevel",
+            CraftingStationLevel = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "NecromancerHoodCraftingStationLevel",
                 1, new ConfigDescription("Crafting station level required to craft Necromancer Hood", null,
                 new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            CraftingCost = plugin.Config.Bind("NecromancerHood (Server Synced)", "NecromancerHoodCraftingCosts",
+            CraftingCost = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "NecromancerHoodCraftingCosts",
                DefaultRecipe, new ConfigDescription("Materials needed to craft Necromancer Hood. None or Blank will use Default settings.", null,
                 new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            NecromancySkillBonus = plugin.Config.Bind("NecromancerHood (Server Synced)", "NecromancerHoodSkillBonus",
+            NecromancySkillBonus = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "NecromancerHoodSkillBonus",
                 10, new ConfigDescription("How much wearing the item should raise the Necromancy level (set to 0 to have no set effect at all).", null,
                 new ConfigurationManagerAttributes { IsAdminOnly = true }));
         }

--- a/ChebsNecromancy/Items/Armor/Player/SpectralShroud.cs
+++ b/ChebsNecromancy/Items/Armor/Player/SpectralShroud.cs
@@ -39,51 +39,51 @@ namespace ChebsNecromancy.Items
         {
             base.CreateConfigs(plugin);
 
-            Allowed = plugin.Config.Bind("SpectralShroud (Server Synced)", "SpectralShroudAllowed",
+            Allowed = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "SpectralShroudAllowed",
                 true, new ConfigDescription("Whether crafting a Spectral Shroud is allowed or not.", null,
                 new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            CraftingStationRequired = plugin.Config.Bind("SpectralShroud (Server Synced)", "SpectralShroudCraftingStation",
+            CraftingStationRequired = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "SpectralShroudCraftingStation",
                 CraftingTable.Workbench, new ConfigDescription("Crafting station where Spectral Shroud is available", null,
                 new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            CraftingStationLevel = plugin.Config.Bind("SpectralShroud (Server Synced)", "SpectralShroudCraftingStationLevel",
+            CraftingStationLevel = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "SpectralShroudCraftingStationLevel",
                 1, new ConfigDescription("Crafting station level required to craft Spectral Shroud", null,
                 new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            CraftingCost = plugin.Config.Bind("SpectralShroud (Server Synced)", "SpectralShroudCraftingCosts",
+            CraftingCost = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "SpectralShroudCraftingCosts",
                 DefaultRecipe, new ConfigDescription("Materials needed to craft Spectral Shroud. None or Blank will use Default settings.", null,
                 new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            SpawnWraith = plugin.Config.Bind("SpectralShroud (Server Synced)", "SpectralShroudSpawnWraith",
+            SpawnWraith = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "SpectralShroudSpawnWraith",
                 true, new ConfigDescription("Whether wraiths spawn or not.", null,
                 new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            NecromancySkillBonus = plugin.Config.Bind("SpectralShroud (Server Synced)", "SpectralShroudSkillBonus",
+            NecromancySkillBonus = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "SpectralShroudSkillBonus",
                 10, new ConfigDescription("How much wearing the item should raise the Necromancy level (set to 0 to have no set effect at all).", null,
                 new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            DelayBetweenWraithSpawns = plugin.Config.Bind("SpectralShroud (Server Synced)", "SpectralShroudWraithDelay",
+            DelayBetweenWraithSpawns = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "SpectralShroudWraithDelay",
                 30, new ConfigDescription("How much time must pass after a wraith spawns before a new one is able to spawn.", null,
                 new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            GuardianWraithTierOneQuality = plugin.Config.Bind("SpectralShroud (Server Synced)", "GuardianWraithTierOneQuality",
+            GuardianWraithTierOneQuality = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "GuardianWraithTierOneQuality",
                1, new ConfigDescription("Star Quality of tier 1 GuardianWraith minions", null,
                new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            GuardianWraithTierTwoQuality = plugin.Config.Bind("SpectralShroud (Server Synced)", "GuardianWraithTierTwoQuality",
+            GuardianWraithTierTwoQuality = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "GuardianWraithTierTwoQuality",
                 2, new ConfigDescription("Star Quality of tier 2 GuardianWraith minions", null,
                 new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            GuardianWraithTierTwoLevelReq = plugin.Config.Bind("SpectralShroud (Server Synced)", "GuardianWraithTierTwoLevelReq",
+            GuardianWraithTierTwoLevelReq = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "GuardianWraithTierTwoLevelReq",
                 35, new ConfigDescription("Necromancy skill level required to summon Tier 2 GuardianWraith", null,
                 new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            GuardianWraithTierThreeQuality = plugin.Config.Bind("SpectralShroud (Server Synced)", "GuardianWraithTierThreeQuality",
+            GuardianWraithTierThreeQuality = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "GuardianWraithTierThreeQuality",
                 3, new ConfigDescription("Star Quality of tier 3 GuardianWraith minions", null,
                 new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            GuardianWraithTierThreeLevelReq = plugin.Config.Bind("SpectralShroud (Server Synced)", "GuardianWraithTierThreeLevelReq",
+            GuardianWraithTierThreeLevelReq = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "GuardianWraithTierThreeLevelReq",
                 70, new ConfigDescription("Necromancy skill level required to summon Tier 3 GuardianWraith", null,
                 new ConfigurationManagerAttributes { IsAdminOnly = true }));
         }

--- a/ChebsNecromancy/Items/Wands/DraugrWand.cs
+++ b/ChebsNecromancy/Items/Wands/DraugrWand.cs
@@ -46,68 +46,68 @@ namespace ChebsNecromancy.Items
         {
             base.CreateConfigs(plugin);
 
-            DraugrSetFollowRange = plugin.Config.Bind("DraugrWand (Client)", "DraugrCommandRange",
+            DraugrSetFollowRange = plugin.Config.Bind($"{GetType().Name} (Client)", "DraugrCommandRange",
                 20f, new ConfigDescription("The range from which nearby Draugr will hear your command.", null));
 
-            Allowed = plugin.Config.Bind("DraugrWand (Server Synced)", "DraugrWandAllowed",
+            Allowed = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "DraugrWandAllowed",
                 true, new ConfigDescription("Whether crafting a Draugr Wand is allowed or not.", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            CraftingStationRequired = plugin.Config.Bind("DraugrWand (Server Synced)", "DraugrWandCraftingStation",
+            CraftingStationRequired = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "DraugrWandCraftingStation",
                 CraftingTable.Forge, new ConfigDescription("Crafting station where Draugr Wand is available", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            CraftingStationLevel = plugin.Config.Bind("DraugrWand (Server Synced)", "DraugrWandCraftingStationLevel",
+            CraftingStationLevel = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "DraugrWandCraftingStationLevel",
                 1, new ConfigDescription("Crafting station level required to craft Draugr Wand", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            CraftingCost = plugin.Config.Bind("DraugrWand (Server Synced)", "DraugrWandCraftingCosts",
+            CraftingCost = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "DraugrWandCraftingCosts",
                 DefaultRecipe, new ConfigDescription(
                     "Materials needed to craft Draugr Wand. None or Blank will use Default settings.", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            DraugrAllowed = plugin.Config.Bind("DraugrWand (Server Synced)", "DraugrAllowed",
+            DraugrAllowed = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "DraugrAllowed",
                 true, new ConfigDescription("If false, draugr aren't loaded at all and can't be summoned.", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            DraugrBaseHealth = plugin.Config.Bind("DraugrWand (Server Synced)", "DraugrBaseHealth",
+            DraugrBaseHealth = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "DraugrBaseHealth",
                 80f, new ConfigDescription("HP = BaseHealth + NecromancyLevel * HealthMultiplier", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            DraugrHealthMultiplier = plugin.Config.Bind("DraugrWand (Server Synced)", "DraugrHealthMultiplier",
+            DraugrHealthMultiplier = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "DraugrHealthMultiplier",
                 2.5f, new ConfigDescription("HP = BaseHealth + NecromancyLevel * HealthMultiplier", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            DraugrTierOneQuality = plugin.Config.Bind("DraugrWand (Server Synced)", "DraugrTierOneQuality",
+            DraugrTierOneQuality = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "DraugrTierOneQuality",
                 1, new ConfigDescription("Star Quality of tier 1 Draugr minions", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            DraugrTierTwoQuality = plugin.Config.Bind("DraugrWand (Server Synced)", "DraugrTierTwoQuality",
+            DraugrTierTwoQuality = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "DraugrTierTwoQuality",
                 2, new ConfigDescription("Star Quality of tier 2 Draugr minions", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            DraugrTierTwoLevelReq = plugin.Config.Bind("DraugrWand (Server Synced)", "DraugrTierTwoLevelReq",
+            DraugrTierTwoLevelReq = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "DraugrTierTwoLevelReq",
                 35, new ConfigDescription("Necromancy skill level required to summon Tier 2 Draugr", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            DraugrTierThreeQuality = plugin.Config.Bind("DraugrWand (Server Synced)", "DraugrTierThreeQuality",
+            DraugrTierThreeQuality = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "DraugrTierThreeQuality",
                 3, new ConfigDescription("Star Quality of tier 3 Draugr minions", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            DraugrTierThreeLevelReq = plugin.Config.Bind("DraugrWand (Server Synced)", "DraugrTierThreeLevelReq",
+            DraugrTierThreeLevelReq = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "DraugrTierThreeLevelReq",
                 70, new ConfigDescription("Necromancy skill level required to summon Tier 3 Draugr", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            DraugrMeatRequiredConfig = plugin.Config.Bind("DraugrWand (Server Synced)", "DraugrMeatRequired",
+            DraugrMeatRequiredConfig = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "DraugrMeatRequired",
                 2, new ConfigDescription("How many pieces of meat it costs to make a Draugr.", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            DraugrBoneFragmentsRequiredConfig = plugin.Config.Bind("DraugrWand (Server Synced)",
+            DraugrBoneFragmentsRequiredConfig = plugin.Config.Bind($"{GetType().Name} (Server Synced)",
                 "DraugrBoneFragmentsRequired",
                 6, new ConfigDescription("How many bone fragments it costs to make a Draugr.", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            necromancyLevelIncrease = plugin.Config.Bind("DraugrWand (Server Synced)", "DraugrNecromancyLevelIncrease",
+            necromancyLevelIncrease = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "DraugrNecromancyLevelIncrease",
                 1.5f, new ConfigDescription(
                     "How much creating a Draugr contributes to your Necromancy level increasing.", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));

--- a/ChebsNecromancy/Items/Wands/OrbOfBeckoning.cs
+++ b/ChebsNecromancy/Items/Wands/OrbOfBeckoning.cs
@@ -32,19 +32,19 @@ namespace ChebsNecromancy.Items
             //
             // don't call base.CreateConfig because we want to omit the archer button
 
-            Allowed = plugin.Config.Bind("OrbOfBeckoning (Server Synced)", "OrbOfBeckoningAllowed",
+            Allowed = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "OrbOfBeckoningAllowed",
                 true, new ConfigDescription("Whether crafting an Orb of Beckoning is allowed or not.", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            CraftingStationRequired = plugin.Config.Bind("OrbOfBeckoning (Server Synced)", "OrbOfBeckoningCraftingStation",
+            CraftingStationRequired = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "OrbOfBeckoningCraftingStation",
                 CraftingTable.Workbench, new ConfigDescription("Crafting station where it's available", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            CraftingStationLevel = plugin.Config.Bind("OrbOfBeckoning (Server Synced)", "OrbOfBeckoningCraftingStationLevel",
+            CraftingStationLevel = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "OrbOfBeckoningCraftingStationLevel",
                 1, new ConfigDescription("Crafting station level required to craft.", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            CraftingCost = plugin.Config.Bind("OrbOfBeckoning (Server Synced)", "OrbOfBeckoningCraftingCosts",
+            CraftingCost = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "OrbOfBeckoningCraftingCosts",
                 DefaultRecipe, new ConfigDescription("Materials needed to craft it. None or Blank will use Default settings.", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
             

--- a/ChebsNecromancy/Items/Wands/SkeletonWand.cs
+++ b/ChebsNecromancy/Items/Wands/SkeletonWand.cs
@@ -48,89 +48,89 @@ namespace ChebsNecromancy.Items
         {
             base.CreateConfigs(plugin);
 
-            SkeletonSetFollowRange = plugin.Config.Bind("SkeletonWand (Client)", "SkeletonCommandRange",
+            SkeletonSetFollowRange = plugin.Config.Bind($"{GetType().Name} (Client)", "SkeletonCommandRange",
                 20f, new ConfigDescription("The distance which nearby skeletons will hear your commands."));
 
-            Allowed = plugin.Config.Bind("SkeletonWand (Server Synced)", "SkeletonWandAllowed",
+            Allowed = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "SkeletonWandAllowed",
                 true, new ConfigDescription("Whether crafting a Skeleton Wand is allowed or not.", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            CraftingStationRequired = plugin.Config.Bind("SkeletonWand (Server Synced)", "SkeletonWandCraftingStation",
+            CraftingStationRequired = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "SkeletonWandCraftingStation",
                 CraftingTable.Workbench, new ConfigDescription("Crafting station where Skeleton Wand is available",
                     null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            CraftingStationLevel = plugin.Config.Bind("SkeletonWand (Server Synced)",
+            CraftingStationLevel = plugin.Config.Bind($"{GetType().Name} (Server Synced)",
                 "SkeletonWandCraftingStationLevel",
                 1, new ConfigDescription("Crafting station level required to craft Skeleton Wand", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            CraftingCost = plugin.Config.Bind("SkeletonWand (Server Synced)", "SkeletonWandCraftingCosts",
+            CraftingCost = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "SkeletonWandCraftingCosts",
                 DefaultRecipe, new ConfigDescription(
                     "Materials needed to craft Skeleton Wand. None or Blank will use Default settings.", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            SkeletonsAllowed = plugin.Config.Bind("SkeletonWand (Server Synced)", "SkeletonsAllowed",
-                true, new ConfigDescription("If false, skeletons aren't loaded at all and can't be summoned.", null,
+            SkeletonsAllowed = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "SkeletonsAllowed",
+                true, new ConfigDescription("If false, skeletons can't be summoned.", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            BoneFragmentsRequiredConfig = plugin.Config.Bind("SkeletonWand (Server Synced)", "BoneFragmentsRequired",
+            BoneFragmentsRequiredConfig = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "BoneFragmentsRequired",
                 6, new ConfigDescription("The amount of Bone Fragments required to craft a skeleton.", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            SkeletonBaseHealth = plugin.Config.Bind("SkeletonWand (Server Synced)", "SkeletonBaseHealth",
+            SkeletonBaseHealth = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "SkeletonBaseHealth",
                 20f, new ConfigDescription("HP = BaseHealth + NecromancyLevel * HealthMultiplier", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            SkeletonHealthMultiplier = plugin.Config.Bind("SkeletonWand (Server Synced)", "SkeletonHealthMultiplier",
+            SkeletonHealthMultiplier = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "SkeletonHealthMultiplier",
                 1.25f, new ConfigDescription("HP = BaseHealth + NecromancyLevel * HealthMultiplier", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            SkeletonTierOneQuality = plugin.Config.Bind("SkeletonWand (Server Synced)", "SkeletonTierOneQuality",
+            SkeletonTierOneQuality = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "SkeletonTierOneQuality",
                 1, new ConfigDescription("Star Quality of tier 1 Skeleton minions", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            SkeletonTierTwoQuality = plugin.Config.Bind("SkeletonWand (Server Synced)", "SkeletonTierTwoQuality",
+            SkeletonTierTwoQuality = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "SkeletonTierTwoQuality",
                 2, new ConfigDescription("Star Quality of tier 2 Skeleton minions", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            SkeletonTierTwoLevelReq = plugin.Config.Bind("SkeletonWand (Server Synced)", "SkeletonTierTwoLevelReq",
+            SkeletonTierTwoLevelReq = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "SkeletonTierTwoLevelReq",
                 35, new ConfigDescription("Necromancy skill level required to summon Tier 2 Skeleton", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            SkeletonTierThreeQuality = plugin.Config.Bind("SkeletonWand (Server Synced)", "SkeletonTierThreeQuality",
+            SkeletonTierThreeQuality = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "SkeletonTierThreeQuality",
                 3, new ConfigDescription("Star Quality of tier 3 Skeleton minions", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            SkeletonTierThreeLevelReq = plugin.Config.Bind("SkeletonWand (Server Synced)", "SkeletonTierThreeLevelReq",
+            SkeletonTierThreeLevelReq = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "SkeletonTierThreeLevelReq",
                 90, new ConfigDescription("Necromancy skill level required to summon Tier 3 Skeleton", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            PoisonSkeletonBaseHealth = plugin.Config.Bind("SkeletonWand (Server Synced)", "PoisonSkeletonBaseHealth",
+            PoisonSkeletonBaseHealth = plugin.Config.Bind($"{GetType().Name} (Server Synced)", "PoisonSkeletonBaseHealth",
                 100f, new ConfigDescription("HP = BaseHealth + NecromancyLevel * HealthMultiplier", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            PoisonSkeletonLevelRequirementConfig = plugin.Config.Bind("SkeletonWand (Server Synced)",
+            PoisonSkeletonLevelRequirementConfig = plugin.Config.Bind($"{GetType().Name} (Server Synced)",
                 "PoisonSkeletonLevelRequired",
                 50, new ConfigDescription("The Necromancy level needed to summon a Poison Skeleton.", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            PoisonSkeletonGuckRequiredConfig = plugin.Config.Bind("SkeletonWand (Server Synced)",
+            PoisonSkeletonGuckRequiredConfig = plugin.Config.Bind($"{GetType().Name} (Server Synced)",
                 "PoisonSkeletonGuckRequired",
                 1, new ConfigDescription("The amount of Guck required to craft a Poison Skeleton.", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            WoodcutterSkeletonFlintRequiredConfig = plugin.Config.Bind("SkeletonWand (Server Synced)",
+            WoodcutterSkeletonFlintRequiredConfig = plugin.Config.Bind($"{GetType().Name} (Server Synced)",
                 "WoodcutterSkeletonFlintRequired",
                 1, new ConfigDescription("The amount of Flint required to craft a Woodcutter Skeleton.", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            MinerSkeletonAntlerRequiredConfig = plugin.Config.Bind("SkeletonWand (Server Synced)",
+            MinerSkeletonAntlerRequiredConfig = plugin.Config.Bind($"{GetType().Name} (Server Synced)",
                 "MinerSkeletonAntlerRequired",
                 1, new ConfigDescription("The amount of HardAntler required to craft a Miner Skeleton.", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
 
-            SkeletonArmorValueMultiplier = plugin.Config.Bind("SkeletonWand (Server Synced)",
+            SkeletonArmorValueMultiplier = plugin.Config.Bind($"{GetType().Name} (Server Synced)",
                 "SkeletonArmorValueMultiplier",
                 1f, new ConfigDescription(
                     "If you find the armor value for skeletons to be too low, you can multiply it here. By default, a skeleton wearing iron armor will have an armor value of 42 (14+14+14). A multiplier of 1.5 will cause this armor value to increase to 63.",
@@ -522,6 +522,11 @@ namespace ChebsNecromancy.Items
 
             if (skeletonType is SkeletonMinion.SkeletonType.None)
                 skeletonType = SpawnSkeletonWarriorMinion(armorType);
+
+            if (skeletonType is SkeletonMinion.SkeletonType.None)
+            {
+                return;
+            }
 
             // if players have decided to foolishly restrict their power and
             // create a *cough* LIMIT *spits*... check that here

--- a/ChebsNecromancy/Items/Wands/SkeletonWand.cs
+++ b/ChebsNecromancy/Items/Wands/SkeletonWand.cs
@@ -347,6 +347,19 @@ namespace ChebsNecromancy.Items
             Player player = Player.m_localPlayer;
 
             if (!ExtraResourceConsumptionUnlocked) return SkeletonMinion.SkeletonType.None;
+            
+            // check for bones
+            if (BoneFragmentsRequiredConfig.Value > 0)
+            {
+                int boneFragmentsInInventory = player.GetInventory().CountItems("$item_bonefragments");
+
+                if (boneFragmentsInInventory < BoneFragmentsRequiredConfig.Value)
+                {
+                    MessageHud.instance.ShowMessage(MessageHud.MessageType.Center,
+                        "$friendlyskeletonwand_notenoughbones");
+                    return SkeletonMinion.SkeletonType.None;
+                }
+            }
 
             if (MinerSkeletonAntlerRequiredConfig.Value > 0)
             {

--- a/ChebsNecromancy/Minions/SkeletonMinerMinion.cs
+++ b/ChebsNecromancy/Minions/SkeletonMinerMinion.cs
@@ -18,13 +18,13 @@ namespace ChebsNecromancy.Minions
                 3, new ConfigDescription("The tier of the skeleton's tool: 0 (deerbone), 1 (bronze), 2 (iron), 3 (black metal).", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
             UpdateDelay = plugin.Config.Bind("SkeletonMiner (Server Synced)", "SkeletonMinerUpdateDelay",
-                6f, new ConfigDescription("The delay, in seconds, between wood searching attempts. Attention: small values may impact performance.", null,
+                6f, new ConfigDescription("The delay, in seconds, between rock/ore searching attempts. Attention: small values may impact performance.", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
             LookRadius = plugin.Config.Bind("SkeletonMiner (Server Synced)", "LookRadius",
-                50f, new ConfigDescription("How far it can see wood. High values may damage performance.", null,
+                50f, new ConfigDescription("How far it can see rock/ore. High values may damage performance.", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
             RoamRange = plugin.Config.Bind("SkeletonMiner (Server Synced)", "RoamRange",
-                50f, new ConfigDescription("How far it will randomly run to in search of wood.", null,
+                50f, new ConfigDescription("How far it will randomly run to in search of rock/ore.", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));
             RockInternalIDsList = plugin.Config.Bind("SkeletonMiner (Server Synced)", "RockInternalIDsList",
                 DefaultOresList, new ConfigDescription("The types of rock the miner will attempt to mine. Internal IDs only.", null,

--- a/ChebsNecromancy/Package/README.md
+++ b/ChebsNecromancy/Package/README.md
@@ -129,6 +129,8 @@ You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
 Date | Version | Notes
 --- | --- | ---
+05/04/2023 | 2.5.14 | Fix bug where bones get consumed even when not enough are in the inventory; fix config descriptions
+31/03/2023 | 2.5.13 | Character.m_tamed is also checked when looking for hostiles so that things like tamed animals aren't detected; Configurable teleport durability cost & cooldown
 28/03/2023 | 2.5.11 | don't log error if NPC is using the Orb of Beckoning
 28/03/2023 | 2.5.10 | improve repair pylon behaviour; upgrade to jotunn 1.11.2; make neckro update more null resistant
 27/03/2023 | 2.5.9 | fix a null object exception for structure friendly-fire code; ships ignore minion impact damage; fix problem of duplicate resource drops on death if crate is enabled

--- a/ChebsNecromancy/Package/manifest.json
+++ b/ChebsNecromancy/Package/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "name": "ChebsNecromancy",
   "description": "Cheb's Necromancy adds Necromancy to Valheim via craftable wands and structures. Minions will follow you, guard your base, and perform menial tasks.",
-  "version_number": "2.5.13",
+  "version_number": "2.5.14",
   "website_url": "https://github.com/jpw1991/chebs-necromancy",
   "dependencies": [
     "ValheimModding-Jotunn-2.11.2"

--- a/ChebsNecromancy/Package/manifest.json
+++ b/ChebsNecromancy/Package/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "name": "ChebsNecromancy",
   "description": "Cheb's Necromancy adds Necromancy to Valheim via craftable wands and structures. Minions will follow you, guard your base, and perform menial tasks.",
-  "version_number": "2.5.14",
+  "version_number": "2.5.15",
   "website_url": "https://github.com/jpw1991/chebs-necromancy",
   "dependencies": [
     "ValheimModding-Jotunn-2.11.2"

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
 Date | Version | Notes
 --- | --- | ---
+05/04/2023 | 2.5.14 | Fix bug where bones get consumed even when not enough are in the inventory; fix config descriptions
+31/03/2023 | 2.5.13 | Character.m_tamed is also checked when looking for hostiles so that things like tamed animals aren't detected; Configurable teleport durability cost & cooldown
 28/03/2023 | 2.5.11 | don't log error if NPC is using the Orb of Beckoning
 28/03/2023 | 2.5.10 | improve repair pylon behaviour; upgrade to jotunn 1.11.2; make neckro update more null resistant
 27/03/2023 | 2.5.9 | fix a null object exception for structure friendly-fire code; ships ignore minion impact damage; fix problem of duplicate resource drops on death if crate is enabled


### PR DESCRIPTION
# Description

- Fix bug where bones get consumed even when not enough are in the inventory
- fix bug where worker could be spawned with insufficient bones
- fix config descriptions
- 2.5.15: miners prioritize copper, silver, and tin over rocks

## Testing - Built pre-release [2.5.14](https://github.com/jpw1991/chebs-necromancy/releases/tag/2.5.14)

- [ ] Fix bug where bones get consumed even when not enough are in the inventory
  - Try summoning a minion without enough bones in the inventory
  - Ensure the bones aren't erroneously consumed
- [ ] fix bug where worker could be spawned with insufficient bones
  - Try summoning a worker (1 flint or 1 hardantler) with insufficient bones
  - Confirm that it is not possible
- [ ] fix config descriptions
  - check the config descriptions for typos
- [ ] 2.5.15: miners prioritize copper, silver, and tin over rocks
  - Ensure that you are using [2.5.15](https://github.com/jpw1991/chebs-necromancy/releases/tag/2.5.15-UNSAFE) (Attention: this particular 2.5.15 release has no version checking in order to assist a Nexus user's experiment)
  - Check to see if miners prioritize nearer metal nodes rather than nearer rocks