### PR TITLE
3.0.5: add container whitelist to Neckros & limit their selection to …

### DIFF
--- a/ChebsNecromancy/BasePlugin.cs
+++ b/ChebsNecromancy/BasePlugin.cs
@@ -34,11 +34,11 @@ namespace ChebsNecromancy
     {
         public const string PluginGuid = "com.chebgonaz.ChebsNecromancy";
         public const string PluginName = "ChebsNecromancy";
-        public const string PluginVersion = "3.0.4";
+        public const string PluginVersion = "3.0.5";
         private const string ConfigFileName =  PluginGuid + ".cfg";
         private static readonly string ConfigFileFullPath = Path.Combine(Paths.ConfigPath, ConfigFileName);
         
-        public readonly System.Version ChebsValheimLibraryVersion = new("1.0.0");
+        public readonly System.Version ChebsValheimLibraryVersion = new("1.1.0");
 
         private readonly Harmony harmony = new(PluginGuid);
 

--- a/ChebsNecromancy/ChebsNecromancy.csproj
+++ b/ChebsNecromancy/ChebsNecromancy.csproj
@@ -177,7 +177,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Common\" />
     <Folder Include="Package\plugins\" />
     <Folder Include="Items\" />
     <Folder Include="Commands\" />

--- a/ChebsNecromancy/Package/README.md
+++ b/ChebsNecromancy/Package/README.md
@@ -135,6 +135,7 @@ You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
 Date | Version | Notes
 --- | --- | ---
+11/04/2023 | 3.0.5 | add container whitelist to Neckros & limit their selection to just player made containers
 11/04/2023 | 3.0.4 | upgrade ChebsValheimLib to 1.0.1 to fix ToolTier
 09/04/2023 | 3.0.1 | Refactor to be compatible with Cheb's Mercenaries; bug fixes
 05/04/2023 | 2.5.15 | Miners prioritize copper, silver, and tin over rocks

--- a/ChebsNecromancy/Package/manifest.json
+++ b/ChebsNecromancy/Package/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "name": "ChebsNecromancy",
   "description": "Cheb's Necromancy adds Necromancy to Valheim via craftable wands and structures. Minions will follow you, guard your base, and perform menial tasks.",
-  "version_number": "3.0.4",
+  "version_number": "3.0.5",
   "website_url": "https://github.com/jpw1991/chebs-necromancy",
   "dependencies": [
     "ValheimModding-Jotunn-2.11.2"

--- a/ChebsNecromancy/Structures/FarmingPylon.cs
+++ b/ChebsNecromancy/Structures/FarmingPylon.cs
@@ -53,7 +53,7 @@ namespace ChebsNecromancy.Structures
 
             var pickableList = plugin.ModConfig(ChebsRecipeConfig.ObjectName, "FarmingPylonPickableList", DefaultPickables,
                 "A list of pickable IDs.", null, true);
-            PickableList = new (pickableList, s => s.Split(',').ToList());
+            PickableList = new MemoryConfigEntry<string, List<string>>(pickableList, s => s?.Split(',').ToList());
         }
         
         public new static void UpdateRecipe()

--- a/ChebsNecromancy/Structures/FarmingPylon.cs
+++ b/ChebsNecromancy/Structures/FarmingPylon.cs
@@ -13,14 +13,13 @@ namespace ChebsNecromancy.Structures
     {
         public static ConfigEntry<float> SightRadius;
         public static ConfigEntry<float> UpdateInterval;
-        public static ConfigEntry<string> PickableList;
+        public static MemoryConfigEntry<string, List<string>> PickableList;
 
         private const string DefaultPickables =
             "Pickable_Barley,Pickable_Barley_Wild,Pickable_Carrot,Pickable_Dandelion,Pickable_Flax,Pickable_Flax_Wild,Pickable_Mushroom,Pickable_Mushroom_blue,Pickable_Mushroom_JotunPuffs,Pickable_Mushroom_Magecap,Pickable_Mushroom_yellow,Pickable_Onion,Pickable_SeedCarrot,Pickable_SeedOnion,Pickable_SeedTurnip,Pickable_Thistle,Pickable_Turnip";
 
         private int _itemMask;
         private int _pieceMaskNonSolid;
-        private List<string> _pickableList;
 
         public new static ChebsRecipe ChebsRecipeConfig = new()
         {
@@ -52,8 +51,9 @@ namespace ChebsNecromancy.Structures
                 "How long a Farming Pylon waits between checking containers and crops (lower values may negatively impact performance).",
                 plugin.FloatQuantityValue, true);
 
-            PickableList = plugin.ModConfig(ChebsRecipeConfig.ObjectName, "FarmingPylonPickableList", DefaultPickables,
+            var pickableList = plugin.ModConfig(ChebsRecipeConfig.ObjectName, "FarmingPylonPickableList", DefaultPickables,
                 "A list of pickable IDs.", null, true);
+            PickableList = new (pickableList, s => s.Split(',').ToList());
         }
         
         public new static void UpdateRecipe()
@@ -65,7 +65,6 @@ namespace ChebsNecromancy.Structures
         {
             _itemMask = LayerMask.GetMask("item");
             _pieceMaskNonSolid = LayerMask.GetMask("piece_nonsolid");
-            _pickableList = PickableList.Value.Split(',').ToList();
             StartCoroutine(LookForCrops());
         }
 
@@ -99,7 +98,7 @@ namespace ChebsNecromancy.Structures
             foreach (var col in nearbyPickables)
             {
                 var pickable = col.GetComponentInParent<Pickable>();
-                if (pickable != null && _pickableList.Exists(item => pickable.name.Contains(item)))//.Contains(pickable.m_itemPrefab.name))
+                if (pickable != null && PickableList.Value.Exists(item => pickable.name.Contains(item)))//.Contains(pickable.m_itemPrefab.name))
                 {
                     pickable.m_nview.InvokeRPC("Pick");
                 }

--- a/ChebsNecromancy/Structures/RepairPylon.cs
+++ b/ChebsNecromancy/Structures/RepairPylon.cs
@@ -79,12 +79,12 @@ namespace ChebsNecromancy.Structures
             var alwaysRepair = plugin.ModConfig(ChebsRecipeConfig.ObjectName, "AlwaysRepair", "piece_sharpstakes,piece_dvergr_sharpstakes",
                 "These prefabs are always repaired no matter their damage and ignore the RepairWoodWhen/RepairOtherWhen thresholds. This is good for defensive things like stakes which should always be kept at maximum health. Please use a comma-delimited list of prefab names.",
                 null, true);
-            AlwaysRepair = new (alwaysRepair, s => s.Split(',').ToList());
+            AlwaysRepair = new MemoryConfigEntry<string, List<string>>(alwaysRepair, s => s?.Split(',').ToList());
             
             var fuels = plugin.ModConfig(ChebsRecipeConfig.ObjectName, "Fuels", "Resin,GreydwarfEye,Pukeberries",
                 "The items that are consumed as fuel when repairing. Please use a comma-delimited list of prefab names.",
                 null, true);
-            Fuels = new (fuels, s => s.Split(',').ToList());
+            Fuels = new MemoryConfigEntry<string, List<string>>(fuels, s => s?.Split(',').ToList());
         }
         
         private void Awake()

--- a/ChebsNecromancy/Structures/TreasurePylon.cs
+++ b/ChebsNecromancy/Structures/TreasurePylon.cs
@@ -69,7 +69,7 @@ namespace ChebsNecromancy.Structures
             var containerWhitelist = plugin.ModConfig(ChebsRecipeConfig.ObjectName, "ContainerWhitelist", "piece_chest_wood",
                 "The containers that are sorted. Please use a comma-delimited list of prefab names.",
                 null, true);
-            ContainerWhitelist = new (containerWhitelist, s => s.Split(',').ToList());
+            ContainerWhitelist = new MemoryConfigEntry<string, List<string>>(containerWhitelist, s => s?.Split(',').ToList());
         }
 
         private void Awake()

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ You can find the github [here](https://github.com/jpw1991/chebs-necromancy).
 
 Date | Version | Notes
 --- | --- | ---
+11/04/2023 | 3.0.5 | add container whitelist to Neckros & limit their selection to just player made containers
 11/04/2023 | 3.0.4 | upgrade ChebsValheimLib to 1.0.1 to fix ToolTier
 09/04/2023 | 3.0.1 | Refactor to be compatible with Cheb's Mercenaries; bug fixes
 05/04/2023 | 2.5.15 | Miners prioritize copper, silver, and tin over rocks


### PR DESCRIPTION
# Desc

3.0.5: add container whitelist to Neckros & limit their selection to just player made containers

## Testing ([pre-compiled 3.0.5](https://github.com/jpw1991/chebs-necromancy/releases/tag/3.0.5) for convenience)

Make sure you're using the newest version of [Cheb's Valheim Library](https://github.com/jpw1991/chebs-valheim-library) otherwise you'll get errors.

- Add container whitelist to Neckros
  - [ ] Test that Neckros only deposit into prefabs listed in the config eg. wooden boxes
- Testing of dynamic config stuff needed
  - **Repair Pylon:** Try dynamically changing the list; ensure everything works for:
    - [ ] `Fuels`
    - [ ] `AlwaysRepair`
  - **Farming Pylon:** Try dynamically changing the list; ensure everything works for:
    - [ ] `PickableList`
  - **Treasure pylon**
    - [ ] `ContainerWhitelist`
  - **Neckro Gatherer**
    - [ ] `ContainerWhitelist`