### PR TITLE
166 dropondeath inconsistencies

### DIFF
--- a/ChebsNecromancy/BasePlugin.cs
+++ b/ChebsNecromancy/BasePlugin.cs
@@ -10,7 +10,6 @@ using BepInEx;
 using BepInEx.Configuration;
 using ChebsNecromancy.Commands;
 using ChebsNecromancy.CustomPrefabs;
-using ChebsNecromancy.Items;
 using ChebsNecromancy.Items.Armor.Player;
 using ChebsNecromancy.Items.Wands;
 using ChebsNecromancy.Minions;
@@ -19,7 +18,6 @@ using ChebsNecromancy.Minions.Skeletons;
 using ChebsNecromancy.Structures;
 using ChebsValheimLibrary;
 using ChebsValheimLibrary.Common;
-using ChebsValheimLibrary.Items.Tools;
 using HarmonyLib;
 using Jotunn;
 using Jotunn.Configs;
@@ -38,11 +36,11 @@ namespace ChebsNecromancy
     {
         public const string PluginGuid = "com.chebgonaz.ChebsNecromancy";
         public const string PluginName = "ChebsNecromancy";
-        public const string PluginVersion = "3.3.2";
+        public const string PluginVersion = "3.3.3";
         private const string ConfigFileName =  PluginGuid + ".cfg";
         private static readonly string ConfigFileFullPath = Path.Combine(Paths.ConfigPath, ConfigFileName);
         
-        public readonly System.Version ChebsValheimLibraryVersion = new("1.2.2");
+        public readonly System.Version ChebsValheimLibraryVersion = new("1.2.3");
 
         private readonly Harmony harmony = new(PluginGuid);
 
@@ -93,7 +91,7 @@ namespace ChebsNecromancy
         
         private void Awake()
         {
-            if (!ChebsValheimLibrary.Base.VersionCheck(ChebsValheimLibraryVersion, out string message))
+            if (!Base.VersionCheck(ChebsValheimLibraryVersion, out string message))
             {
                 Jotunn.Logger.LogWarning(message);
             }

--- a/ChebsNecromancy/CustomPrefabs/OrbOfBeckoningProjectile.cs
+++ b/ChebsNecromancy/CustomPrefabs/OrbOfBeckoningProjectile.cs
@@ -1,9 +1,7 @@
 using System.Collections.Generic;
-using ChebsNecromancy.Items;
 using ChebsNecromancy.Items.Wands;
 using ChebsNecromancy.Minions;
 using UnityEngine;
-using Logger = Jotunn.Logger;
 
 namespace ChebsNecromancy.CustomPrefabs
 {

--- a/ChebsNecromancy/Items/Wands/DraugrWand.cs
+++ b/ChebsNecromancy/Items/Wands/DraugrWand.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using BepInEx;
 using BepInEx.Configuration;
 using ChebsNecromancy.Minions;
 using ChebsNecromancy.Minions.Draugr;
-using ChebsValheimLibrary.Common;
 using ChebsValheimLibrary.Items;
 using ChebsValheimLibrary.Minions;
 using Jotunn;
@@ -14,8 +12,6 @@ using Jotunn.Managers;
 using UnityEngine;
 using UnityEngine.UI;
 using Logger = Jotunn.Logger;
-using Object = UnityEngine.Object;
-using Random = UnityEngine.Random;
 
 namespace ChebsNecromancy.Items.Wands
 {

--- a/ChebsNecromancy/Items/Wands/Wand.cs
+++ b/ChebsNecromancy/Items/Wands/Wand.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using BepInEx;
 using BepInEx.Configuration;
 using ChebsNecromancy.CustomPrefabs;
@@ -8,7 +7,6 @@ using ChebsValheimLibrary.Minions;
 using Jotunn.Configs;
 using Jotunn.Managers;
 using UnityEngine;
-using Logger = Jotunn.Logger;
 
 namespace ChebsNecromancy.Items.Wands
 {

--- a/ChebsNecromancy/Minions/BattleNeckroMinion.cs
+++ b/ChebsNecromancy/Minions/BattleNeckroMinion.cs
@@ -1,9 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using BepInEx;
 using BepInEx.Configuration;
-using ChebsNecromancy.Items;
 using ChebsNecromancy.Items.Wands;
 using ChebsValheimLibrary.Common;
 using ChebsValheimLibrary.Minions;
@@ -155,7 +153,7 @@ namespace ChebsNecromancy.Minions
         public static void InstantiateBattleNeckro(int quality, float playerNecromancyLevel)
         {
             var player = Player.m_localPlayer;
-            var prefabName = BattleNeckroMinion.PrefabName;
+            var prefabName = PrefabName;
             var prefab = ZNetScene.instance.GetPrefab(prefabName);
             if (!prefab)
             {
@@ -187,9 +185,10 @@ namespace ChebsNecromancy.Minions
             minion.UndeadMinionMaster = player.GetPlayerName();
 
             // handle refunding of resources on death
-            var characterDrop = minion.GenerateDeathDrops(DropOnDeath, ItemsCost);
-            
-            if (characterDrop == null) return;
+            if (DropOnDeath.Value != DropType.Everything) return;
+
+            var characterDrop = spawnedChar.AddComponent<CharacterDrop>();
+            GenerateDeathDrops(characterDrop, ItemsCost);
 
             // the component won't be remembered by the game on logout because
             // only what is on the prefab is remembered. Even changes to the prefab

--- a/ChebsNecromancy/Minions/Draugr/DraugrMinion.cs
+++ b/ChebsNecromancy/Minions/Draugr/DraugrMinion.cs
@@ -419,41 +419,43 @@ namespace ChebsNecromancy.Minions.Draugr
             minion.UndeadMinionMaster = player.GetPlayerName();
 
             // handle refunding of resources on death
-            CharacterDrop characterDrop = null;
-
-            switch (skeletonType)
+            if (DropOnDeath.Value == DropType.Nothing) return;
+            
+            var characterDrop = spawnedChar.AddComponent<CharacterDrop>();
+            if (DropOnDeath.Value == DropType.Everything)
             {
-                case DraugrType.WarriorTier1:
-                case DraugrType.WarriorTier2:
-                case DraugrType.WarriorTier3:
-                case DraugrType.WarriorTier4:
-                case DraugrType.WarriorNeedle:
-                    characterDrop = minion.GenerateDeathDrops(DraugrWarriorMinion.DropOnDeath, DraugrWarriorMinion.ItemsCost);
-                    break;
-                case DraugrType.ArcherTier1:
-                    characterDrop = minion.GenerateDeathDrops(DraugrArcherTier1Minion.DropOnDeath, DraugrArcherTier1Minion.ItemsCost);
-                    break;
-                case DraugrType.ArcherTier2:
-                    characterDrop = minion.GenerateDeathDrops(DraugrArcherTier2Minion.DropOnDeath, DraugrArcherTier2Minion.ItemsCost);
-                    break;
-                case DraugrType.ArcherTier3:
-                    characterDrop = minion.GenerateDeathDrops(DraugrArcherTier3Minion.DropOnDeath, DraugrArcherTier3Minion.ItemsCost);
-                    break;
-                case DraugrType.ArcherPoison:
-                    characterDrop = minion.GenerateDeathDrops(DraugrArcherPoisonMinion.DropOnDeath, DraugrArcherPoisonMinion.ItemsCost);
-                    break;
-                case DraugrType.ArcherFire:
-                    characterDrop = minion.GenerateDeathDrops(DraugrArcherFireMinion.DropOnDeath, DraugrArcherFireMinion.ItemsCost);
-                    break;
-                case DraugrType.ArcherFrost:
-                    characterDrop = minion.GenerateDeathDrops(DraugrArcherFrostMinion.DropOnDeath, DraugrArcherFrostMinion.ItemsCost);
-                    break;
-                case DraugrType.ArcherSilver:
-                    characterDrop = minion.GenerateDeathDrops(DraugrArcherSilverMinion.DropOnDeath, DraugrArcherSilverMinion.ItemsCost);
-                    break;
+                switch (skeletonType)
+                {
+                    case DraugrType.WarriorTier1:
+                    case DraugrType.WarriorTier2:
+                    case DraugrType.WarriorTier3:
+                    case DraugrType.WarriorTier4:
+                    case DraugrType.WarriorNeedle:
+                        GenerateDeathDrops(characterDrop, DraugrWarriorMinion.ItemsCost);
+                        break;
+                    case DraugrType.ArcherTier1:
+                        GenerateDeathDrops(characterDrop, DraugrArcherTier1Minion.ItemsCost);
+                        break;
+                    case DraugrType.ArcherTier2:
+                        GenerateDeathDrops(characterDrop, DraugrArcherTier2Minion.ItemsCost);
+                        break;
+                    case DraugrType.ArcherTier3:
+                        GenerateDeathDrops(characterDrop, DraugrArcherTier3Minion.ItemsCost);
+                        break;
+                    case DraugrType.ArcherPoison:
+                        GenerateDeathDrops(characterDrop, DraugrArcherPoisonMinion.ItemsCost);
+                        break;
+                    case DraugrType.ArcherFire:
+                        GenerateDeathDrops(characterDrop, DraugrArcherFireMinion.ItemsCost);
+                        break;
+                    case DraugrType.ArcherFrost:
+                        GenerateDeathDrops(characterDrop, DraugrArcherFrostMinion.ItemsCost);
+                        break;
+                    case DraugrType.ArcherSilver:
+                        GenerateDeathDrops(characterDrop, DraugrArcherSilverMinion.ItemsCost);
+                        break;
+                }
             }
-
-            if (characterDrop == null) return;
 
             switch (armorType)
             {

--- a/ChebsNecromancy/Minions/LeechMinion.cs
+++ b/ChebsNecromancy/Minions/LeechMinion.cs
@@ -1,9 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using BepInEx;
 using BepInEx.Configuration;
-using ChebsNecromancy.Items;
 using ChebsNecromancy.Items.Wands;
 using ChebsValheimLibrary.Common;
 using ChebsValheimLibrary.Minions;
@@ -208,7 +206,10 @@ namespace ChebsNecromancy.Minions
             minion.UndeadMinionMaster = player.GetPlayerName();
 
             // handle refunding of resources on death
-            var characterDrop = minion.GenerateDeathDrops(DropOnDeath, ItemsCost);
+            if (DropOnDeath.Value != DropType.Everything) return;
+
+            var characterDrop = spawnedChar.AddComponent<CharacterDrop>();
+            GenerateDeathDrops(characterDrop, ItemsCost);
 
             // the component won't be remembered by the game on logout because
             // only what is on the prefab is remembered. Even changes to the prefab

--- a/ChebsNecromancy/Minions/Skeletons/PoisonSkeletonMinion.cs
+++ b/ChebsNecromancy/Minions/Skeletons/PoisonSkeletonMinion.cs
@@ -37,7 +37,7 @@ namespace ChebsNecromancy.Minions.Skeletons
                 Logger.LogError("ScaleStats: Character component is null!");
                 return;
             }
-            var health = BaseHealth.Value + necromancyLevel * SkeletonMinion.SkeletonHealthMultiplier.Value;
+            var health = BaseHealth.Value + necromancyLevel * SkeletonHealthMultiplier.Value;
             character.SetMaxHealth(health);
             character.SetHealth(health);
         }

--- a/ChebsNecromancy/Minions/Skeletons/SkeletonMinion.cs
+++ b/ChebsNecromancy/Minions/Skeletons/SkeletonMinion.cs
@@ -416,58 +416,60 @@ namespace ChebsNecromancy.Minions.Skeletons
 
             minion.UndeadMinionMaster = player.GetPlayerName();
 
+            if (DropOnDeath.Value == DropType.Nothing) return;
+
             // handle refunding of resources on death
-            CharacterDrop characterDrop = null;
-
-            switch (skeletonType)
+            var characterDrop = spawnedChar.AddComponent<CharacterDrop>();
+            if (DropOnDeath.Value == DropType.Everything)
             {
-                case SkeletonType.WarriorTier1:
-                case SkeletonType.WarriorTier2:
-                case SkeletonType.WarriorTier3:
-                case SkeletonType.WarriorTier4:
-                case SkeletonType.WarriorNeedle:
-                    characterDrop = minion.GenerateDeathDrops(SkeletonWarriorMinion.DropOnDeath, SkeletonWarriorMinion.ItemsCost);
-                    break;
-                case SkeletonType.ArcherTier1:
-                    characterDrop = minion.GenerateDeathDrops(SkeletonArcherTier1Minion.DropOnDeath, SkeletonArcherTier1Minion.ItemsCost);
-                    break;
-                case SkeletonType.ArcherTier2:
-                    characterDrop = minion.GenerateDeathDrops(SkeletonArcherTier2Minion.DropOnDeath, SkeletonArcherTier2Minion.ItemsCost);
-                    break;
-                case SkeletonType.ArcherTier3:
-                    characterDrop = minion.GenerateDeathDrops(SkeletonArcherTier3Minion.DropOnDeath, SkeletonArcherTier3Minion.ItemsCost);
-                    break;
-                case SkeletonType.ArcherPoison:
-                    characterDrop = minion.GenerateDeathDrops(SkeletonArcherPoisonMinion.DropOnDeath, SkeletonArcherPoisonMinion.ItemsCost);
-                    break;
-                case SkeletonType.ArcherFire:
-                    characterDrop = minion.GenerateDeathDrops(SkeletonArcherFireMinion.DropOnDeath, SkeletonArcherFireMinion.ItemsCost);
-                    break;
-                case SkeletonType.ArcherFrost:
-                    characterDrop = minion.GenerateDeathDrops(SkeletonArcherFrostMinion.DropOnDeath, SkeletonArcherFrostMinion.ItemsCost);
-                    break;
-                case SkeletonType.ArcherSilver:
-                    characterDrop = minion.GenerateDeathDrops(SkeletonArcherSilverMinion.DropOnDeath, SkeletonArcherSilverMinion.ItemsCost);
-                    break;
-                case SkeletonType.MageTier1:
-                case SkeletonType.MageTier2:
-                case SkeletonType.MageTier3:
-                    characterDrop = minion.GenerateDeathDrops(SkeletonMageMinion.DropOnDeath, SkeletonMageMinion.ItemsCost);
-                    break;
-                case SkeletonType.PoisonTier1:
-                case SkeletonType.PoisonTier2:
-                case SkeletonType.PoisonTier3:
-                    characterDrop = minion.GenerateDeathDrops(PoisonSkeletonMinion.DropOnDeath, PoisonSkeletonMinion.ItemsCost);
-                    break;
-                case SkeletonType.Woodcutter:
-                    characterDrop = minion.GenerateDeathDrops(SkeletonWoodcutterMinion.DropOnDeath, SkeletonWoodcutterMinion.ItemsCost);
-                    break;
-                case SkeletonType.Miner:
-                    characterDrop = minion.GenerateDeathDrops(SkeletonMinerMinion.DropOnDeath, SkeletonMinerMinion.ItemsCost);
-                    break;
+                switch (skeletonType)
+                {
+                    case SkeletonType.WarriorTier1:
+                    case SkeletonType.WarriorTier2:
+                    case SkeletonType.WarriorTier3:
+                    case SkeletonType.WarriorTier4:
+                    case SkeletonType.WarriorNeedle:
+                        GenerateDeathDrops(characterDrop, SkeletonWarriorMinion.ItemsCost);
+                        break;
+                    case SkeletonType.ArcherTier1:
+                        GenerateDeathDrops(characterDrop, SkeletonArcherTier1Minion.ItemsCost);
+                        break;
+                    case SkeletonType.ArcherTier2:
+                        GenerateDeathDrops(characterDrop, SkeletonArcherTier2Minion.ItemsCost);
+                        break;
+                    case SkeletonType.ArcherTier3:
+                        GenerateDeathDrops(characterDrop, SkeletonArcherTier3Minion.ItemsCost);
+                        break;
+                    case SkeletonType.ArcherPoison:
+                        GenerateDeathDrops(characterDrop, SkeletonArcherPoisonMinion.ItemsCost);
+                        break;
+                    case SkeletonType.ArcherFire:
+                        GenerateDeathDrops(characterDrop, SkeletonArcherFireMinion.ItemsCost);
+                        break;
+                    case SkeletonType.ArcherFrost:
+                        GenerateDeathDrops(characterDrop, SkeletonArcherFrostMinion.ItemsCost);
+                        break;
+                    case SkeletonType.ArcherSilver:
+                        GenerateDeathDrops(characterDrop, SkeletonArcherSilverMinion.ItemsCost);
+                        break;
+                    case SkeletonType.MageTier1:
+                    case SkeletonType.MageTier2:
+                    case SkeletonType.MageTier3:
+                        GenerateDeathDrops(characterDrop, SkeletonMageMinion.ItemsCost);
+                        break;
+                    case SkeletonType.PoisonTier1:
+                    case SkeletonType.PoisonTier2:
+                    case SkeletonType.PoisonTier3:
+                        GenerateDeathDrops(characterDrop, PoisonSkeletonMinion.ItemsCost);
+                        break;
+                    case SkeletonType.Woodcutter:
+                        GenerateDeathDrops(characterDrop, SkeletonWoodcutterMinion.ItemsCost);
+                        break;
+                    case SkeletonType.Miner:
+                        GenerateDeathDrops(characterDrop, SkeletonMinerMinion.ItemsCost);
+                        break;
+                }
             }
-
-            if (characterDrop == null) return;
 
             switch (armorType)
             {

--- a/ChebsNecromancy/Minions/UndeadMinion.cs
+++ b/ChebsNecromancy/Minions/UndeadMinion.cs
@@ -1,9 +1,6 @@
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using BepInEx;
 using BepInEx.Configuration;
-using ChebsNecromancy.Items;
 using ChebsNecromancy.Items.Armor.Player;
 using ChebsValheimLibrary.Common;
 using ChebsValheimLibrary.Minions;

--- a/ChebsNecromancy/Package/manifest.json
+++ b/ChebsNecromancy/Package/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "name": "ChebsNecromancy",
   "description": "Cheb's Necromancy adds Necromancy to Valheim via craftable wands and structures. Minions will follow you, guard your base, and perform menial tasks.",
-  "version_number": "3.3.2",
+  "version_number": "3.3.3",
   "website_url": "https://github.com/jpw1991/chebs-necromancy",
   "dependencies": [
     "ValheimModding-Jotunn-2.11.2"

--- a/ChebsNecromancy/Patches/CharacterDropPatches.cs
+++ b/ChebsNecromancy/Patches/CharacterDropPatches.cs
@@ -29,9 +29,8 @@ namespace ChebsNecromancy.Patches
         {
             if (BasePlugin.BoneFragmentsDroppedAmountMin.Value >= 0
                 && BasePlugin.BoneFragmentsDroppedAmountMax.Value > 0
-                // for some stupid reason, the GuardianWraith somehow drops bones even though it shouldn't even have
-                // a CharacterDrop component on it. I guess somehow it's being added on. Just ignore it
-                && !__instance.TryGetComponent(out GuardianWraithMinion _))
+                // no extra bones from undead minions
+                && !__instance.TryGetComponent(out UndeadMinion _))
             {
                 CharacterDrop.Drop bones = new()
                 {

--- a/ChebsNecromancy/Properties/AssemblyInfo.cs
+++ b/ChebsNecromancy/Properties/AssemblyInfo.cs
@@ -4,14 +4,15 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("ChebsNecromancy")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("ChebsNecromancy")]
-[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyTitle("Cheb's Necromancy")]
+[assembly: AssemblyDescription("Cheb's Necromancy adds Necromancy to Valheim via craftable wands and structures. " +
+                               "Minions will follow you, guard your base, and perform menial tasks.")]
+[assembly: AssemblyConfiguration("Release")]
+[assembly: AssemblyCompany("Cheb Gonaz")]
+[assembly: AssemblyProduct("Cheb's Necromancy")]
+[assembly: AssemblyCopyright("Copyright Â©  2022")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
+[assembly: AssemblyCulture("en")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
@@ -31,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.0.1.0")]
-[assembly: AssemblyFileVersion("0.0.1.0")]
+[assembly: AssemblyVersion("3.3.3.0")]
+[assembly: AssemblyFileVersion("3.3.3.0")]
 

--- a/ChebsNecromancy/Structures/NeckroGathererPylon.cs
+++ b/ChebsNecromancy/Structures/NeckroGathererPylon.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using BepInEx.Configuration;
-
 using ChebsNecromancy.Minions;
 using ChebsValheimLibrary.Common;
 using ChebsValheimLibrary.Minions;

--- a/ChebsNecromancy/Structures/RefuelerPylon.cs
+++ b/ChebsNecromancy/Structures/RefuelerPylon.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using BepInEx.Configuration;
-
 using ChebsValheimLibrary.Common;
 using ChebsValheimLibrary.Structures;
 using UnityEngine;

--- a/ChebsNecromancy/Structures/RepairPylon.cs
+++ b/ChebsNecromancy/Structures/RepairPylon.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using BepInEx.Configuration;
-
 using ChebsValheimLibrary.Common;
 using ChebsValheimLibrary.Structures;
 using UnityEngine;

--- a/ChebsNecromancy/Structures/SpiritPylon.cs
+++ b/ChebsNecromancy/Structures/SpiritPylon.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Reflection;
 using BepInEx.Configuration;
-
 using ChebsValheimLibrary.Common;
 using ChebsValheimLibrary.Structures;
 using UnityEngine;

--- a/ChebsNecromancy/Structures/TreasurePylon.cs
+++ b/ChebsNecromancy/Structures/TreasurePylon.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using BepInEx.Configuration;
-
-using ChebsNecromancy.Minions;
 using ChebsValheimLibrary.Common;
 using ChebsValheimLibrary.Minions;
 using ChebsValheimLibrary.Structures;


### PR DESCRIPTION
Ok so here's how it should work:

```cs
        public enum DropType
        {
            Nothing,       // generate no CharacterDrop at all
            JustResources, // just save the armor type eg. iron ingots
            Everything,    // drop everything that was used to create the minion eg. bones, meat, iron ingots
        }
```

## Testing

Test with [3.3.3](https://github.com/jpw1991/chebs-necromancy/releases/tag/3.3.3)

How it should work:

Minion | Armor | Item Costs | Drops Setting | Result
--- | --- | --- | --- | ---
Skeleton Warrior | None | `BoneFragments:6` | Nothing | Nothing
Skeleton Warrior | None | `BoneFragments:6` | JustResources | Nothing
Skeleton Warrior | None | `BoneFragments:6` | Everything | 6 Bone fragments
Skeleton Warrior | Bronze | `BoneFragments:6` | Nothing | Nothing
Skeleton Warrior | Bronze | `BoneFragments:6` | JustResources | Bronze
Skeleton Warrior | Bronze | `BoneFragments:6` | Everything | Bronze, 6 Bone fragments