### PR TITLE
Update BatBeacon.cs: fixed Bat Beacon icon name

### DIFF
--- a/ChebsNecromancy/Structures/BatBeacon.cs
+++ b/ChebsNecromancy/Structures/BatBeacon.cs
@@ -22,7 +22,7 @@ namespace ChebsNecromancy.Structures
         public new static ChebsRecipe ChebsRecipeConfig = new()
         {
             DefaultRecipe = "FineWood:10,Silver:5,Guck:15",
-            IconName = "chebgonaz_batbeacon_icon.png",
+            IconName = "chebgonaz_batpylon_icon.png",
             PieceTable = "_HammerPieceTable",
             PieceCategory = "Misc",
             PieceName = "$chebgonaz_batbeacon_name",


### PR DESCRIPTION
I received this error from mod while using AzuDevMod:

[Error  : AzuDevMod] Failed to load asset 'chebgonaz_batbeacon_icon.png' of type 'UnityEngine.Sprite'.

I found the name of Bat Beacon icon at this wiki link: https://github.com/jpw1991/chebs-necromancy/wiki

I changed to the name of Bat Beacon file in that wiki page